### PR TITLE
Upgraded Apache HttpClient Dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     testImplementation("commons-codec:commons-codec:1.+")
 
     testRuntimeOnly("org.apache.httpcomponents:httpclient:4.5.14")
-    testRuntimeOnly("org.apache.httpcomponents.client5:httpclient5:5.1.+")
+    testRuntimeOnly("org.apache.httpcomponents.client5:httpclient5:5.2.+")
 
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:latest.release")

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -34,13 +34,13 @@ recipeList:
       oldArtifactId: httpclient
       newGroupId: org.apache.httpcomponents.client5
       newArtifactId: httpclient5
-      newVersion: 5.1.x
+      newVersion: 5.2.x
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.apache.httpcomponents
       oldArtifactId: httpcore
       newGroupId: org.apache.httpcomponents.core5
       newArtifactId: httpcore5
-      newVersion: 5.1.x
+      newVersion: 5.2.x
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit

--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -64,8 +64,8 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                 </dependencies>
             </project>
             """, spec -> spec.after(pom -> {
-              Matcher version = Pattern.compile("5\\.1\\.\\d+").matcher(pom);
-              assertThat(version.find()).describedAs("Expected 5.1.x in %s", pom).isTrue();
+              Matcher version = Pattern.compile("5\\.2\\.\\d+").matcher(pom);
+              assertThat(version.find()).describedAs("Expected 5.2.x in %s", pom).isTrue();
               return """
                 <project>
                     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION

## What's changed?
Upgraded Apache HttpClient Dependency to 5.2.x

## What's your motivation?
With this migration, we can able to migrate `org.apache.httpcomponents.core5:httpcore5` automatically without manual intervention.

## Anyone you would like to review specifically?
@timtebeek

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files
