### PR TITLE
replace Apache Commons Collections FastArrayList

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-commons-collections-3-4.yml
+++ b/src/main/resources/META-INF/rewrite/apache-commons-collections-3-4.yml
@@ -38,6 +38,9 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.commons.collections.map.IdentityMap
       newFullyQualifiedTypeName: java.util.IdentityHashMap
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.commons.collections.FastArrayList
+      newFullyQualifiedTypeName: java.util.concurrent.CopyOnWriteArrayList
   - org.openrewrite.java.ChangeStaticFieldToMethod:
       oldClassName: org.apache.commons.collections.MapUtils
       oldFieldName: EMPTY_MAP

--- a/src/test/java/org/openrewrite/apache/commons/collections/UpgradeApacheCommonsCollections_3_4Test.java
+++ b/src/test/java/org/openrewrite/apache/commons/collections/UpgradeApacheCommonsCollections_3_4Test.java
@@ -47,6 +47,7 @@ class UpgradeApacheCommonsCollections_3_4Test implements RewriteTest {
               import org.apache.commons.collections.CollectionUtils;
               import org.apache.commons.collections.map.IdentityMap;
               import org.apache.commons.collections.MapUtils;
+              import org.apache.commons.collections.FastArrayList;
 
               import java.util.Map;
 
@@ -56,6 +57,7 @@ class UpgradeApacheCommonsCollections_3_4Test implements RewriteTest {
                       CollectionUtils.reverseArray(input);
                       IdentityMap identityMap = new IdentityMap();
                       Map emptyMap = MapUtils.EMPTY_MAP;
+                      FastArrayList fastList = new FastArrayList(100);
                   }
               }
               """,
@@ -65,6 +67,7 @@ class UpgradeApacheCommonsCollections_3_4Test implements RewriteTest {
               import java.util.Collections;
               import java.util.IdentityHashMap;
               import java.util.Map;
+              import java.util.concurrent.CopyOnWriteArrayList;
 
               class Test {
                   static void helloApacheCollections() {
@@ -72,6 +75,7 @@ class UpgradeApacheCommonsCollections_3_4Test implements RewriteTest {
                       CollectionUtils.reverseArray(input);
                       IdentityHashMap identityMap = new IdentityHashMap();
                       Map emptyMap = Collections.emptyMap();
+                      CopyOnWriteArrayList fastList = new CopyOnWriteArrayList(100);
                   }
               }
               """


### PR DESCRIPTION
Apache Commons Collections FastArrayList exists in 3.x, but does not exist in 4.x

<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Apache Commons Collections recipe

## What's your motivation?

To make it easier to migrate to Apache Commons Collections 4.x

## Anything in particular you'd like reviewers to focus on?

n/a

## Anyone you would like to review specifically?

n/a

## Have you considered any alternatives or workarounds?

n/a

## Any additional context

Commons Collections 4.x release notes
https://commons.apache.org/proper/commons-collections/release_4_0.html


### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
