### PR TITLE
Adding new migrations for HTTP5 Client

### DIFF
--- a/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class AddTimeUnitArgument extends Recipe {

--- a/src/main/java/org/openrewrite/apache/httpclient5/MigrateAuthScope.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/MigrateAuthScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2024 the original author or authors.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/openrewrite/apache/httpclient5/MigrateAuthScope.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/MigrateAuthScope.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.apache.httpclient5;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+
+public class NewStatusLine extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Replaces deprecated `HttpResponse::getStatusLine()`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "`HttpResponse::getStatusLine()` was deprecated in 4.x, so we replace it for `new StatusLine(HttpResponse)`. " +
+                "Ideally we will try to simplify method chains for `getStatusCode`, `getProtocolVersion` and `getReasonPhrase`, " +
+                "but there are some scenarios where the `StatusLine` object is assigned or used directly, and we need to " +
+                "instantiate the object.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaVisitor<ExecutionContext>() {
+            final MethodMatcher matcher = new MethodMatcher("org.apache.hc.core5.http.HttpResponse getStatusLine()");
+
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
+                if (matcher.matches(m)) {
+                    maybeAddImport("org.apache.hc.core5.http.message.StatusLine");
+                    return JavaTemplate.builder("new StatusLine(#{any(org.apache.hc.core5.http.HttpResponse)})")
+                            .imports("org.apache.hc.core5.http.message.StatusLine")
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "httpcore5"))
+                            .build()
+                            .apply(updateCursor(m), m.getCoordinates().replace(), m.getSelect());
+                }
+                return m;
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/apache/httpclient5/NewStatusLine.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/NewStatusLine.java
@@ -15,6 +15,8 @@
  */
 package org.openrewrite.apache.httpclient5;
 
+import lombok.EqualsAndHashCode;
+import lombok.Value;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -24,7 +26,10 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.J;
 
+@Value
+@EqualsAndHashCode(callSuper = false)
 public class NewStatusLine extends Recipe {
+
     @Override
     public String getDisplayName() {
         return "Replaces deprecated `HttpResponse::getStatusLine()`";

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -45,6 +45,7 @@ recipeList:
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit
   - org.openrewrite.apache.httpclient5.StatusLine
+  - org.openrewrite.apache.httpclient5.MigrateAuthScope
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
@@ -93,6 +94,9 @@ recipeList:
       oldPackageName: org.apache.http.impl.client
       newPackageName: org.apache.hc.client5.http.impl.classic
   # Fixing specific mappings
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.impl.client.BasicAuthCache
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.BasicAuthCache
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.BasicAuthCache
       newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.BasicAuthCache
@@ -379,6 +383,12 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.DefaultHttpResponseParser
       newFullyQualifiedTypeName: org.apache.hc.core5.http.impl.io.DefaultHttpResponseParser
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.PoolingClientConnectionManager
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.SchemeRegistryFactory
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.DefaultSchemePortResolver
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.conn
@@ -425,6 +435,12 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.HttpConnectionFactory
       newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.HttpRequest
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpRequest
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.HttpResponse
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpResponse
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateAuthScopeTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateAuthScopeTest.java
@@ -1,4 +1,52 @@
-import static org.junit.jupiter.api.Assertions.*;
-class MigrateAuthScopeTest {
-  
+package org.openrewrite.apache.httpclient5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+class MigrateAuthScopeTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpath("httpclient", "httpcore", "httpclient5", "httpcore5"))
+          .afterTypeValidationOptions(TypeValidation.none())
+          .recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite")
+            .build()
+            .activateRecipes("org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5")
+          );
+    }
+
+    @DocumentExample
+    @Test
+    void authScopeAnyTest() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+            import org.apache.http.auth.AuthScope;
+            
+            class A {
+                void method() {
+                    AuthScope any = AuthScope.ANY;
+                }
+            }
+            """, """
+            import org.apache.hc.client5.http.auth.AuthScope;
+            
+            class A {
+                void method() {
+                    AuthScope any = new AuthScope(null, -1);
+                }
+            }
+            """
+          )
+        );
+    }
 }

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateAuthScopeTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateAuthScopeTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class MigrateAuthScopeTest {
+  
+}

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateAuthScopeTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateAuthScopeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.apache.httpclient5;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- **Adding new migrations for Apache Http 4 to 5 client**

## What's changed?
Add new recipes to migrate to migrate and fixes most of #2's compilation errors.

## What's your motivation?
Migrate Apache http4 client applications

## Anything in particular you'd like reviewers to focus on?
No.

## Anyone you would like to review specifically?
No one.

## Have you considered any alternatives or workarounds?
N/A.

## Any additional context
No.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
