### PR TITLE
Handle change in constructor signature for `HttpHost`.

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -441,6 +441,12 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.http.HttpResponse
       newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpResponse
+  # Fixing argument order change
+  - org.openrewrite.java.ReorderMethodArguments:
+      methodPattern: org.apache.hc.core5.http.HttpHost <constructor>(java.lang.String, int, java.lang.String)
+      oldParameterNames: [hostname, port, scheme]
+      newParameterNames: [scheme, hostname, port]
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -446,6 +446,14 @@ recipeList:
       methodPattern: org.apache.hc.core5.http.HttpHost <constructor>(java.lang.String, int, java.lang.String)
       oldParameterNames: [hostname, port, scheme]
       newParameterNames: [scheme, hostname, port]
+  - org.openrewrite.java.ReorderMethodArguments:
+      methodPattern: org.apache.hc.core5.http.HttpHost <constructor>(java.net.InetAddress, int, java.lang.String)
+      oldParameterNames: [address, port, scheme]
+      newParameterNames: [scheme, address, port]
+  - org.openrewrite.java.ReorderMethodArguments:
+      methodPattern: org.apache.hc.core5.http.HttpHost <constructor>(java.net.InetAddress, java.lang.String, int, java.lang.String)
+      oldParameterNames: [address, hostname, port, scheme]
+      newParameterNames: [scheme, address, hostname, port]
 
 ---
 type: specs.openrewrite.org/v1beta/recipe


### PR DESCRIPTION
## What's changed?
Handle change in constructor signature for `HttpHost`.

See docs here:
(old version)
https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpHost.html

(new version)
https://hc.apache.org/httpcomponents-core-5.2.x/current/httpcore5/apidocs/org/apache/hc/core5/http/HttpHost.html

See 

## What's your motivation?
We have handled this for our internal migration, so I just want to add this upstream so that others can use this.

Thank you for this automatic migration! 👍 