### PR TITLE
Upgrade all Apache POI dependencies to 3.17

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-poi-3-17.yml
+++ b/src/main/resources/META-INF/rewrite/apache-poi-3-17.yml
@@ -28,6 +28,16 @@ recipeList:
       newGroupId: org.apache.poi
       newArtifactId: poi
       newVersion: 3.x
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.apache.poi
+      artifactId: poi
+      newVersion: 3.x
+      retainVersions: []
+  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
+      groupId: org.apache.poi
+      artifactId: poi-ooxml
+      newVersion: 3.x
+      retainVersions: []
   - org.openrewrite.apache.poi.ReplaceSetBoldweightWithSetBoldRecipes
   - org.openrewrite.apache.poi.ReplaceSetCellTypeRecipes
   - org.openrewrite.java.migrate.ChangeMethodInvocationReturnType:

--- a/src/main/resources/META-INF/rewrite/apache-poi-3-17.yml
+++ b/src/main/resources/META-INF/rewrite/apache-poi-3-17.yml
@@ -30,14 +30,8 @@ recipeList:
       newVersion: 3.x
   - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
       groupId: org.apache.poi
-      artifactId: poi
+      artifactId: poi*
       newVersion: 3.x
-      retainVersions: []
-  - org.openrewrite.java.dependencies.UpgradeDependencyVersion:
-      groupId: org.apache.poi
-      artifactId: poi-ooxml
-      newVersion: 3.x
-      retainVersions: []
   - org.openrewrite.apache.poi.ReplaceSetBoldweightWithSetBoldRecipes
   - org.openrewrite.apache.poi.ReplaceSetCellTypeRecipes
   - org.openrewrite.java.migrate.ChangeMethodInvocationReturnType:


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->
Ensuring repositories with the current and proper group ID for `org.apache.poi:poi` will be updated to the latest minor of 3.x and not just the old group ID of `poi:poi`.  Also, includes an upgrade to artifact ID `poi-ooxml` which has a compile dependency of `poi`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
Improving the outcomes of the recipe

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->
N/A

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->
N/A

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->
N/A

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
