### PR TITLE
Migrate ProxyAuthenticationStrategy

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -136,6 +136,9 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.BasicCredentialsProvider
       newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.impl.client.ProxyAuthenticationStrategy
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.auth


### PR DESCRIPTION
## What's changed?

`ProxyAuthenticationStrategy` doesn't exist in httpclient5 anymore.

Ref: https://stackoverflow.com/questions/76993237/how-to-set-proxyauthenticationstrategy-in-httpclientbuilder

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
