### PR TITLE
Change getAllHeaders to getHeaders

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -472,6 +472,9 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.apache.hc.client5.http.config.RequestConfig.Builder setSocketTimeout(int)
       newMethodName: setResponseTimeout
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.http.HttpMessage getAllHeaders()
+      newMethodName: getHeaders
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit


### PR DESCRIPTION
## What's changed?
`org.apache.http.HttpMessage.getAllHeaders()` is moved to `org.apache.hc.core5.http.MessageHeaders.getHeaders()`