### PR TITLE
Migrate `org.apache.commons.lang3.CharEncoding` to StandardCharsets

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-commons-lang-3.yml
+++ b/src/main/resources/META-INF/rewrite/apache-commons-lang-3.yml
@@ -1,0 +1,61 @@
+#
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.apache.commons.lang3.UseStandardCharsets
+displayName: Prefer `java.nio.charset.StandardCharsets`
+description: Prefer the Java standard library's `java.nio.charset.StandardCharsets` over third-party usage of apache's `org.apache.commons.lang3.CharEncoding`.
+tags:
+  - apache
+  - commons
+recipeList:
+  - org.openrewrite.java.ChangeStaticFieldToMethod:
+      oldClassName: org.apache.commons.lang3.CharEncoding
+      oldFieldName: ISO_8859_1
+      newClassName: java.nio.charset.StandardCharsets
+      newTarget: ISO_8859_1
+      newMethodName: name
+  - org.openrewrite.java.ChangeStaticFieldToMethod:
+      oldClassName: org.apache.commons.lang3.CharEncoding
+      oldFieldName: US_ASCII
+      newClassName: java.nio.charset.StandardCharsets
+      newTarget: US_ASCII
+      newMethodName: name
+  - org.openrewrite.java.ChangeStaticFieldToMethod:
+      oldClassName: org.apache.commons.lang3.CharEncoding
+      oldFieldName: UTF_16
+      newClassName: java.nio.charset.StandardCharsets
+      newTarget: UTF_16
+      newMethodName: name
+  - org.openrewrite.java.ChangeStaticFieldToMethod:
+      oldClassName: org.apache.commons.lang3.CharEncoding
+      oldFieldName: UTF_16BE
+      newClassName: java.nio.charset.StandardCharsets
+      newTarget: UTF_16BE
+      newMethodName: name
+  - org.openrewrite.java.ChangeStaticFieldToMethod:
+      oldClassName: org.apache.commons.lang3.CharEncoding
+      oldFieldName: UTF_16LE
+      newClassName: java.nio.charset.StandardCharsets
+      newTarget: UTF_16LE
+      newMethodName: name
+  - org.openrewrite.java.ChangeStaticFieldToMethod:
+      oldClassName: org.apache.commons.lang3.CharEncoding
+      oldFieldName: UTF_8
+      newClassName: java.nio.charset.StandardCharsets
+      newTarget: UTF_8
+      newMethodName: name

--- a/src/main/resources/META-INF/rewrite/apache-commons-lang-3.yml
+++ b/src/main/resources/META-INF/rewrite/apache-commons-lang-3.yml
@@ -18,7 +18,7 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.commons.lang3.UseStandardCharsets
 displayName: Prefer `java.nio.charset.StandardCharsets`
-description: Prefer the Java standard library's `java.nio.charset.StandardCharsets` over third-party usage of apache's `org.apache.commons.lang3.CharEncoding`.
+description: Prefer the Java standard library's `java.nio.charset.StandardCharsets` over `org.apache.commons.lang3.CharEncoding`.
 tags:
   - apache
   - commons

--- a/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsLang3UseStandardCharsetsTest.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsLang3UseStandardCharsetsTest.java
@@ -29,16 +29,13 @@ class ApacheCommonsLang3UseStandardCharsetsTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion().classpath("commons-lang3"))
-          .recipe(Environment.builder()
-            .scanRuntimeClasspath("org.openrewrite")
-            .build()
-            .activateRecipes("org.openrewrite.apache.commons.lang3.UseStandardCharsets"));
+          .recipeFromResource("/META-INF/rewrite/apache-commons-lang-3.yml","org.openrewrite.apache.commons.lang3.UseStandardCharsets");
     }
 
     @SuppressWarnings({"UnusedAssignment", "deprecation"})
     @Test
     @DocumentExample
-    void foo() {
+    void convertCharEncodingFieldsToJdk() {
         // language=java
         rewriteRun(
           java(
@@ -71,6 +68,8 @@ class ApacheCommonsLang3UseStandardCharsetsTest implements RewriteTest {
                       return encoding;
                   }
               }
-              """));
+              """
+          )
+        );
     }
 }

--- a/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsLang3UseStandardCharsetsTest.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsLang3UseStandardCharsetsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.apache.commons.lang;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsLang3UseStandardCharsetsTest.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsLang3UseStandardCharsetsTest.java
@@ -1,0 +1,61 @@
+package org.openrewrite.apache.commons.lang;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ApacheCommonsLang3UseStandardCharsetsTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion().classpath("commons-lang3"))
+          .recipe(Environment.builder()
+            .scanRuntimeClasspath("org.openrewrite")
+            .build()
+            .activateRecipes("org.openrewrite.apache.commons.lang3.UseStandardCharsets"));
+    }
+
+    @SuppressWarnings({"UnusedAssignment", "deprecation"})
+    @Test
+    @DocumentExample
+    void foo() {
+        // language=java
+        rewriteRun(
+          java(
+            """
+              import org.apache.commons.lang3.CharEncoding;
+
+              class A {
+                  String test() {
+                      String encoding = CharEncoding.ISO_8859_1;
+                      encoding = CharEncoding.US_ASCII;
+                      encoding = CharEncoding.UTF_16;
+                      encoding = CharEncoding.UTF_16BE;
+                      encoding = CharEncoding.UTF_16LE;
+                      encoding = CharEncoding.UTF_8;
+                      return encoding;
+                  }
+              }
+              """,
+            """
+              import java.nio.charset.StandardCharsets;
+
+              class A {
+                  String test() {
+                      String encoding = StandardCharsets.ISO_8859_1.name();
+                      encoding = StandardCharsets.US_ASCII.name();
+                      encoding = StandardCharsets.UTF_16.name();
+                      encoding = StandardCharsets.UTF_16BE.name();
+                      encoding = StandardCharsets.UTF_16LE.name();
+                      encoding = StandardCharsets.UTF_8.name();
+                      return encoding;
+                  }
+              }
+              """));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?

Created a new recipe to migrate the character encodings defined in `org.apache.commons.lang3.CharEncoding` to the java standard library implementation.

## What's your motivation?

Partially addresses #4, the only thing remaining is the [isSupported](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/CharEncoding.html#isSupported(java.lang.String)) method. However that would require more thought as just calling [Charset#isSupported](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/charset/Charset.html#isSupported(java.lang.String)) due to the additional null/exception checks that occur within the apache method which mean that it isn't a direct drop in.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
