### PR TITLE
migrate from `sources` to `resolve-sources` in Maven plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ val rewriteVersion = rewriteRecipe.rewriteVersion.get()
 dependencies {
     implementation(platform("org.openrewrite:rewrite-bom:$rewriteVersion"))
     implementation("org.openrewrite:rewrite-java")
+    implementation("org.openrewrite:rewrite-maven")
     implementation("org.openrewrite.recipe:rewrite-java-dependencies:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-logging-frameworks:$rewriteVersion")
     implementation("org.openrewrite.recipe:rewrite-static-analysis:$rewriteVersion")

--- a/src/main/java/org/openrewrite/apache/maven/shared/cleanup/SourcesToResolveSources.java
+++ b/src/main/java/org/openrewrite/apache/maven/shared/cleanup/SourcesToResolveSources.java
@@ -15,7 +15,10 @@
  */
 package org.openrewrite.apache.maven.shared.cleanup;
 
-import org.openrewrite.*;
+import org.openrewrite.Cursor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
 import org.openrewrite.maven.MavenVisitor;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;

--- a/src/main/java/org/openrewrite/apache/maven/shared/cleanup/SourcesToResolveSources.java
+++ b/src/main/java/org/openrewrite/apache/maven/shared/cleanup/SourcesToResolveSources.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.apache.maven.shared.cleanup;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+@SuppressWarnings("ALL")
+public class SourcesToResolveSources extends Recipe {
+    @Override
+    public String getDisplayName() {
+        return "Migrate to `resolve-sources`";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate from `sources` to `resolve-sources` for the `maven-dependency-plugin`.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenVisitor<ExecutionContext>() {
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                return super.visitTag(tag, ctx);
+            }
+        };
+    }
+}

--- a/src/main/java/org/openrewrite/apache/maven/shared/cleanup/SourcesToResolveSources.java
+++ b/src/main/java/org/openrewrite/apache/maven/shared/cleanup/SourcesToResolveSources.java
@@ -59,9 +59,7 @@ public class SourcesToResolveSources extends Recipe {
             }
 
             private boolean isPlugInVersionInRange() {
-                Cursor pluginCursor = getCursor().dropParentUntil(i -> {
-                    return i instanceof Xml.Tag && ((Xml.Tag) i).getName().equals("plugin");
-                });
+                Cursor pluginCursor = getCursor().dropParentUntil(i -> i instanceof Xml.Tag && ((Xml.Tag) i).getName().equals("plugin"));
                 Xml.Tag MavenPluginTag = pluginCursor.getValue();
 
                 String currentVersion = MavenPluginTag.getChildValue("version").orElse(null);

--- a/src/test/java/org/openrewrite/apache/maven/cleanup/SourcesToResolveSourcesTest.java
+++ b/src/test/java/org/openrewrite/apache/maven/cleanup/SourcesToResolveSourcesTest.java
@@ -90,7 +90,7 @@ class SourcesToResolveSourcesTest implements RewriteTest {
     }
 
     @Test
-    void noChange() {
+    void noChangeForOlderVersions() {
         rewriteRun(
           mavenProject("foo",
             //language=xml
@@ -111,6 +111,40 @@ class SourcesToResolveSourcesTest implements RewriteTest {
                                     <execution>
                                         <goals>
                                             <goal>sources</goal>
+                                        </goals>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """
+            ))
+        );
+    }
+
+    @Test
+    void noChangesForResolveSources() {
+        rewriteRun(
+          mavenProject("foo",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-dependency-plugin</artifactId>
+                                <version>3.7.0</version>
+                                <executions>
+                                    <execution>
+                                        <goals>
+                                            <goal>resolve-sources</goal>
                                         </goals>
                                     </execution>
                                 </executions>

--- a/src/test/java/org/openrewrite/apache/maven/cleanup/SourcesToResolveSourcesTest.java
+++ b/src/test/java/org/openrewrite/apache/maven/cleanup/SourcesToResolveSourcesTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.apache.maven.cleanup;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.apache.maven.shared.cleanup.SourcesToResolveSources;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class SourcesToResolveSourcesTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new SourcesToResolveSources());
+    }
+
+    @Test
+    void sourcesToResolveSources() {
+        rewriteRun(
+          mavenProject("foo",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-dependency-plugin</artifactId>
+                                <version>3.8.0</version>
+                                <executions>
+                                    <execution>
+                                        <goals>
+                                            <goal>sources</goal>
+                                        </goals>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """,
+
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-dependency-plugin</artifactId>
+                                <version>3.8.0</version>
+                                <executions>
+                                    <execution>
+                                        <goals>
+                                            <goal>resolve-sources</goal>
+                                        </goals>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """
+            ))
+        );
+    }
+
+    @Test
+    void noChange() {
+        rewriteRun(
+          mavenProject("foo",
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <build>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-dependency-plugin</artifactId>
+                                <version>3.6.9</version>
+                                <executions>
+                                    <execution>
+                                        <goals>
+                                            <goal>sources</goal>
+                                        </goals>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
+                    </build>
+                </project>
+                """
+            ))
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to OpenRewrite!
Feel free to delete any sections that don't apply to your pull request.
-->

## What's changed?
<!-- A brief description of the changes in this pull request -->

create migration recipe to change `sources` to `resolve-sources` for `maven-dependency-plugin` versions >= `3.7.0`

## What's your motivation?
<!-- This can link to close a separate issue, or be described on the pull request itself -->
- closes https://github.com/openrewrite/rewrite-apache/issues/20

## Anything in particular you'd like reviewers to focus on?
<!-- You can also start a discussion on particular aspects of your implementation on the files tab yourself. -->

There is a note indicating this recipe should be in this repo, https://github.com/openrewrite/rewrite-apache/issues/20#issuecomment-2184927354

hopefully that is still the case.

## Anyone you would like to review specifically?
<!-- @mention them here -->

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
