### PR TITLE
Add HttpClient 5 dependency if it only existed transitively

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -45,6 +45,7 @@ recipeList:
       groupId: org.apache.httpcomponents.client5
       artifactId: httpclient5
       version: 5.4.x
+      onlyIfUsing: org.apache.http.impl.client.*
   - org.openrewrite.apache.httpclient5.MigrateRequestConfig
   - org.openrewrite.apache.httpclient5.UsernamePasswordCredentials
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -41,6 +41,10 @@ recipeList:
       newGroupId: org.apache.httpcomponents.core5
       newArtifactId: httpcore5
       newVersion: 5.3.x
+  - org.openrewrite.java.dependencies.AddDependency:
+      groupId: org.apache.httpcomponents.client5
+      artifactId: httpclient5
+      version: 5.4.x
   - org.openrewrite.apache.httpclient5.MigrateRequestConfig
   - org.openrewrite.apache.httpclient5.UsernamePasswordCredentials
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping

--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -27,7 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class UpgradeApacheHttpClient5Test implements RewriteTest {
@@ -603,47 +603,71 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
     @Test
     void migrateDependenciesForTransitive() {
         rewriteRun(
-          //language=xml
-          pomXml(
-            """
-              <project>
-                  <modelVersion>4.0.0</modelVersion>
-                  <groupId>org.example</groupId>
-                  <artifactId>example</artifactId>
-                  <version>1.0.0</version>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.apache.solr</groupId>
-                          <artifactId>solr-solrj</artifactId>
-                          <version>8.11.3</version>
-                      </dependency>
-                  </dependencies>
-              </project>
-              """,
-            spec -> spec.after(pom -> {
-                Matcher version = Pattern.compile("5\\.4\\.\\d+").matcher(pom);
-                assertThat(version.find()).describedAs("Expected 5.4.x in %s", pom).isTrue();
-                return """
-                  <project>
-                      <modelVersion>4.0.0</modelVersion>
-                      <groupId>org.example</groupId>
-                      <artifactId>example</artifactId>
-                      <version>1.0.0</version>
-                      <dependencies>
-                          <dependency>
-                              <groupId>org.apache.httpcomponents.client5</groupId>
-                              <artifactId>httpclient5</artifactId>
-                              <version>%s</version>
-                          </dependency>
-                          <dependency>
-                              <groupId>org.apache.solr</groupId>
-                              <artifactId>solr-solrj</artifactId>
-                              <version>8.11.3</version>
-                          </dependency>
-                      </dependencies>
-                  </project>
-                  """.formatted(version.group(0));
-            })));
+          mavenProject("project",
+            srcMainJava(
+              //language=java
+              java(
+                """
+                  import org.apache.http.impl.client.CloseableHttpClient;
+                  import org.apache.http.impl.client.HttpClients;
+                  public class A {
+                      CloseableHttpClient getClient() {
+                          return HttpClients.createDefault();
+                      }
+                  }
+                  """,
+                """
+                  import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+                  import org.apache.hc.client5.http.impl.classic.HttpClients;
+                  public class A {
+                      CloseableHttpClient getClient() {
+                          return HttpClients.createDefault();
+                      }
+                  }
+                  """
+              )
+            ),
+            //language=xml
+            pomXml(
+              """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.example</groupId>
+                    <artifactId>example</artifactId>
+                    <version>1.0.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.solr</groupId>
+                            <artifactId>solr-solrj</artifactId>
+                            <version>8.11.3</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """,
+              spec -> spec.after(pom -> {
+                  Matcher version = Pattern.compile("5\\.4\\.\\d+").matcher(pom);
+                  assertThat(version.find()).describedAs("Expected 5.4.x in %s", pom).isTrue();
+                  return """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>org.example</groupId>
+                        <artifactId>example</artifactId>
+                        <version>1.0.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.httpcomponents.client5</groupId>
+                                <artifactId>httpclient5</artifactId>
+                                <version>%s</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.solr</groupId>
+                                <artifactId>solr-solrj</artifactId>
+                                <version>8.11.3</version>
+                            </dependency>
+                        </dependencies>
+                    </project>
+                    """.formatted(version.group(0));
+              }))));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

The declarative dependency `UpgradeApacheHttpClient_5`.

## What's your motivation?

The recipe `org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5` only [changes the HttpClient 4 dependency to the HttpClient 5 dependency](https://github.com/openrewrite/rewrite-apache/blob/main/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml#L32-L43) if it has been declared as direct dependency. This is the case for Maven and Gradle projects.

Some projects may receive the HttpClient 4 dependency as a transitive dependency though. As a result, the imports are changed but the HttpClient 5 dependency has not been added leading to a compilation issue.

## Anything in particular you'd like reviewers to focus on?

No

## Anyone you would like to review specifically?

No

## Have you considered any alternatives or workarounds?

No

## Any additional context

No