### PR TITLE
Moving addImport to the end of AbstractLogEnabledToSlf4j

### DIFF
--- a/src/main/java/org/openrewrite/codehaus/plexus/AbstractLogEnabledToSlf4j.java
+++ b/src/main/java/org/openrewrite/codehaus/plexus/AbstractLogEnabledToSlf4j.java
@@ -96,8 +96,6 @@ public class AbstractLogEnabledToSlf4j extends Recipe {
                             }.visitNonNull(cd, ctx, getCursor().getParentTreeCursor());
 
                             // Add a logger field
-                            maybeAddImport("org.slf4j.Logger");
-                            maybeAddImport("org.slf4j.LoggerFactory");
                             cd = (J.ClassDeclaration) AddLogger.addSlf4jLogger(cd, LOGGER_VARIABLE_NAME, ctx)
                                     .visitNonNull(cd, ctx, getCursor().getParentTreeCursor());
                             AtomicReference<J.Identifier> loggerFieldReference = new AtomicReference<>();
@@ -138,6 +136,9 @@ public class AbstractLogEnabledToSlf4j extends Recipe {
                             maybeRemoveImport(PLEXUS_LOGGER);
                             cd = (J.ClassDeclaration) new ChangeType(PLEXUS_LOGGER, "org.slf4j.Logger", false)
                                     .getVisitor().visitNonNull(cd, ctx, getCursor().getParentTreeCursor());
+
+                            maybeAddImport("org.slf4j.Logger");
+                            maybeAddImport("org.slf4j.LoggerFactory");
 
                         }
                         return super.visitClassDeclaration(cd, ctx);


### PR DESCRIPTION
## What's changed?

A minor change in the `AbstractLogEnabledToSlf4j`. Moving the `maybeAddImport` call after all `maybeRemoveImport` calls.

Following https://github.com/openrewrite/rewrite-testing-frameworks/pull/731

## What's your motivation?

To fix one of the class of failures in the CI:
```
    -    private static final Logger LOGGER = LoggerFactory.getLogger(A.class);
    +    private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(A.class);
```
