### PR TITLE
Migrating Apache Http Components HttpMime into the Apache Http Client Client5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     testImplementation("commons-codec:commons-codec:1.+")
 
     testRuntimeOnly("org.apache.httpcomponents:httpclient:4.5.14")
+    testRuntimeOnly("org.apache.httpcomponents:httpmime:4.5.14")
     testRuntimeOnly("org.apache.httpcomponents.client5:httpclient5:5.2.+")
 
     testImplementation("commons-collections:commons-collections:3.2.2")

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -207,6 +207,13 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.io.entity.ContentType
       newFullyQualifiedTypeName: org.apache.hc.core5.http.ContentType
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.entity.mime.MinimalField
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.entity.mime.MimeField
+  # Is needed when change package has bailed early
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.entity.mime.MinimalField
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.entity.mime.MimeField
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl.bootstrap

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -31,6 +31,12 @@ recipeList:
   - org.openrewrite.apache.httpclient4.UpgradeApacheHttpClient_4_5
   - org.openrewrite.java.dependencies.ChangeDependency:
       oldGroupId: org.apache.httpcomponents
+      oldArtifactId: httpmime
+      newGroupId: org.apache.httpcomponents.client5
+      newArtifactId: httpclient5
+      newVersion: 5.4.x
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.apache.httpcomponents
       oldArtifactId: httpclient
       newGroupId: org.apache.httpcomponents.client5
       newArtifactId: httpclient5
@@ -46,6 +52,7 @@ recipeList:
       artifactId: httpclient5
       version: 5.4.x
       onlyIfUsing: org.apache.http.impl.client.*
+  - org.openrewrite.maven.RemoveDuplicateDependencies
   - org.openrewrite.apache.httpclient5.MigrateRequestConfig
   - org.openrewrite.apache.httpclient5.UsernamePasswordCredentials
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
@@ -187,6 +194,12 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.entity
       newPackageName: org.apache.hc.core5.http.io.entity
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.hc.core5.http.io.entity.mime
+      newPackageName: org.apache.hc.client5.http.entity.mime
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.hc.client5.http.entity.mime.content
+      newPackageName: org.apache.hc.client5.http.entity.mime
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.io.entity.ContentLengthStrategy

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -706,23 +706,33 @@ examples:
       import org.apache.http.HttpEntity;
       import org.apache.http.client.methods.HttpGet;
       import org.apache.http.client.methods.HttpUriRequest;
+      import org.apache.http.entity.ContentType;
+      import org.apache.http.entity.mime.MultipartEntityBuilder;
+      import org.apache.http.entity.mime.content.StringBody;
       import org.apache.http.util.EntityUtils;
 
       class A {
           void method(HttpEntity entity, String urlStr) throws Exception {
               HttpUriRequest getRequest = new HttpGet(urlStr);
+              MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+              StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
               EntityUtils.consume(entity);
           }
       }
     after: |
+      import org.apache.hc.core5.http.ContentType;
       import org.apache.hc.core5.http.io.entity.EntityUtils;
       import org.apache.hc.core5.http.HttpEntity;
       import org.apache.hc.client5.http.classic.methods.HttpGet;
       import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+      import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+      import org.apache.hc.client5.http.entity.mime.StringBody;
 
       class A {
           void method(HttpEntity entity, String urlStr) throws Exception {
               HttpUriRequest getRequest = new HttpGet(urlStr);
+              MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+              StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
               EntityUtils.consume(entity);
           }
       }

--- a/src/main/resources/META-INF/rewrite/examples.yml
+++ b/src/main/resources/META-INF/rewrite/examples.yml
@@ -707,6 +707,7 @@ examples:
       import org.apache.http.client.methods.HttpGet;
       import org.apache.http.client.methods.HttpUriRequest;
       import org.apache.http.entity.ContentType;
+      import org.apache.http.entity.mime.MinimalField;
       import org.apache.http.entity.mime.MultipartEntityBuilder;
       import org.apache.http.entity.mime.content.StringBody;
       import org.apache.http.util.EntityUtils;
@@ -716,6 +717,7 @@ examples:
               HttpUriRequest getRequest = new HttpGet(urlStr);
               MultipartEntityBuilder builder = MultipartEntityBuilder.create();
               StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
+              MinimalField field = new MinimalField("A", "B");
               EntityUtils.consume(entity);
           }
       }
@@ -725,6 +727,7 @@ examples:
       import org.apache.hc.core5.http.HttpEntity;
       import org.apache.hc.client5.http.classic.methods.HttpGet;
       import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+      import org.apache.hc.client5.http.entity.mime.MimeField;
       import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
       import org.apache.hc.client5.http.entity.mime.StringBody;
 
@@ -733,6 +736,7 @@ examples:
               HttpUriRequest getRequest = new HttpGet(urlStr);
               MultipartEntityBuilder builder = MultipartEntityBuilder.create();
               StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
+              MimeField field = new MimeField("A", "B");
               EntityUtils.consume(entity);
           }
       }

--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -36,7 +36,7 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
     public void defaults(RecipeSpec spec) {
         spec
           .parser(JavaParser.fromJavaVersion().classpath(
-            "httpclient", "httpcore",
+            "httpclient", "httpcore", "httpmime",
             "httpclient5", "httpcore5"))
           .recipeFromResources("org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5");
     }
@@ -51,24 +51,34 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
               import org.apache.http.HttpEntity;
               import org.apache.http.client.methods.HttpGet;
               import org.apache.http.client.methods.HttpUriRequest;
+              import org.apache.http.entity.ContentType;
+              import org.apache.http.entity.mime.MultipartEntityBuilder;
+              import org.apache.http.entity.mime.content.StringBody;
               import org.apache.http.util.EntityUtils;
 
               class A {
                   void method(HttpEntity entity, String urlStr) throws Exception {
                       HttpUriRequest getRequest = new HttpGet(urlStr);
+                      MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+                      StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
                       EntityUtils.consume(entity);
                   }
               }
               """,
             """
+              import org.apache.hc.core5.http.ContentType;
               import org.apache.hc.core5.http.io.entity.EntityUtils;
               import org.apache.hc.core5.http.HttpEntity;
               import org.apache.hc.client5.http.classic.methods.HttpGet;
               import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+              import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+              import org.apache.hc.client5.http.entity.mime.StringBody;
 
               class A {
                   void method(HttpEntity entity, String urlStr) throws Exception {
                       HttpUriRequest getRequest = new HttpGet(urlStr);
+                      MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+                      StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
                       EntityUtils.consume(entity);
                   }
               }
@@ -78,10 +88,100 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
     }
 
     @Test
+    void doesNotMigrateAlreadyCorrectPackage() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.hc.core5.http.ContentType;
+              import org.apache.hc.core5.http.io.entity.EntityUtils;
+              import org.apache.hc.core5.http.HttpEntity;
+              import org.apache.hc.client5.http.classic.methods.HttpGet;
+              import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+              import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+              import org.apache.hc.client5.http.entity.mime.StringBody;
+
+              class A {
+                  void method(HttpEntity entity, String urlStr) throws Exception {
+                      HttpUriRequest getRequest = new HttpGet(urlStr);
+                      MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+                      StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
+                      EntityUtils.consume(entity);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateDependenciesWhenTwoBecomeOne() {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.apache.httpcomponents</groupId>
+                          <artifactId>httpmime</artifactId>
+                          <version>4.5.14</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>org.apache.httpcomponents</groupId>
+                          <artifactId>httpclient</artifactId>
+                          <version>4.5.14</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher version = Pattern.compile("5\\.4\\.\\d+").matcher(pom);
+                assertThat(version.find()).describedAs("Expected 5.4.x in %s", pom).isTrue();
+                //language=xml
+                return """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.apache.httpcomponents.client5</groupId>
+                              <artifactId>httpclient5</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """.formatted(version.group(0));
+            })));
+    }
+
+    @Test
     void migrateDependencies() {
         rewriteRun(
-          //language=xml
           pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.apache.httpcomponents</groupId>
+                          <artifactId>httpmime</artifactId>
+                          <version>4.5.14</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            //language=xml
             """
               <project>
                   <modelVersion>4.0.0</modelVersion>
@@ -100,6 +200,7 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
             spec -> spec.after(pom -> {
                 Matcher version = Pattern.compile("5\\.4\\.\\d+").matcher(pom);
                 assertThat(version.find()).describedAs("Expected 5.4.x in %s", pom).isTrue();
+                //language=xml
                 return """
                   <project>
                       <modelVersion>4.0.0</modelVersion>

--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -52,6 +52,7 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
               import org.apache.http.client.methods.HttpGet;
               import org.apache.http.client.methods.HttpUriRequest;
               import org.apache.http.entity.ContentType;
+              import org.apache.http.entity.mime.MinimalField;
               import org.apache.http.entity.mime.MultipartEntityBuilder;
               import org.apache.http.entity.mime.content.StringBody;
               import org.apache.http.util.EntityUtils;
@@ -61,6 +62,7 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                       HttpUriRequest getRequest = new HttpGet(urlStr);
                       MultipartEntityBuilder builder = MultipartEntityBuilder.create();
                       StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
+                      MinimalField field = new MinimalField("A", "B");
                       EntityUtils.consume(entity);
                   }
               }
@@ -71,6 +73,7 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
               import org.apache.hc.core5.http.HttpEntity;
               import org.apache.hc.client5.http.classic.methods.HttpGet;
               import org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+              import org.apache.hc.client5.http.entity.mime.MimeField;
               import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
               import org.apache.hc.client5.http.entity.mime.StringBody;
 
@@ -79,6 +82,7 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                       HttpUriRequest getRequest = new HttpGet(urlStr);
                       MultipartEntityBuilder builder = MultipartEntityBuilder.create();
                       StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
+                      MimeField field = new MimeField("A", "B");
                       EntityUtils.consume(entity);
                   }
               }
@@ -107,6 +111,33 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                       MultipartEntityBuilder builder = MultipartEntityBuilder.create();
                       StringBody body = new StringBody("stringbody", ContentType.TEXT_PLAIN);
                       EntityUtils.consume(entity);
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migratesMimeMinimalFieldToMimeField() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.http.entity.mime.MinimalField;
+
+              class A {
+                  void method() {
+                      MinimalField field = new MinimalField("A", "B");
+                  }
+              }
+              """,
+            """
+              import org.apache.hc.client5.http.entity.mime.MimeField;
+
+              class A {
+                  void method() {
+                      MimeField field = new MimeField("A", "B");
                   }
               }
               """


### PR DESCRIPTION
Migrates the Apache's HttpComponents HttpMime for version 4 to HttpComponents HttpClient5

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
