### PR TITLE
Migrating HttpRequestBase's `releaseConnection()` to HttpUriRequestBase's `reset()`

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -519,6 +519,9 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.apache.hc.client5.http.classic.methods.HttpUriRequestBase getURI()
       newMethodName: getUri
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.hc.client5.http.classic.methods.HttpUriRequestBase releaseConnection()
+      newMethodName: reset
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit

--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -661,6 +661,39 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
         );
     }
 
+    @Test
+    void releaseConnectionToReset() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.net.URISyntaxException;
+              import org.apache.http.client.methods.HttpPost;
+
+              class A {
+
+                  private void a() throws URISyntaxException {
+                      HttpPost httpPost = new HttpPost("");
+                      httpPost.releaseConnection();
+                  }
+              }
+              """,
+            """
+              import java.net.URISyntaxException;
+              import org.apache.hc.client5.http.classic.methods.HttpPost;
+
+              class A {
+
+                  private void a() throws URISyntaxException {
+                      HttpPost httpPost = new HttpPost("");
+                      httpPost.reset();
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-apache/issues/67")
     @Test
     void credentialsProviderToStore() {


### PR DESCRIPTION
The method `releaseConnection()` for `HttpRequestBase` in Apache Http Client 4.x was renamed to `reset()` for `HttpUriRequestBase` in Apache Http Client 5.x

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
