### PR TITLE
Migrating `ExceptionUtils.getFullStackTrace(..)` to `ExceptionUtils.getStackTrace(..)`

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-commons-lang-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/apache-commons-lang-2-3.yml
@@ -38,3 +38,6 @@ recipeList:
       oldPackageName: org.apache.commons.lang
       newPackageName: org.apache.commons.lang3
       recursive: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.commons.lang3.exception.ExceptionUtils getFullStackTrace(..)
+      newMethodName: getStackTrace

--- a/src/test/java/org/openrewrite/apache/commons/lang/UpgradeApacheCommonsLang_2_3Test.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/UpgradeApacheCommonsLang_2_3Test.java
@@ -73,4 +73,31 @@ class UpgradeApacheCommonsLang_2_3Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void exceptionUtilsGetFullStackTraceToGetStackTrace() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.commons.lang.exception.ExceptionUtils;
+
+              class A {
+                  String doSomething(Throwable t) {
+                     return ExceptionUtils.getFullStackTrace(t);
+                  }
+              }
+              """,
+            """
+              import org.apache.commons.lang3.exception.ExceptionUtils;
+
+              class A {
+                  String doSomething(Throwable t) {
+                     return ExceptionUtils.getStackTrace(t);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
Simple rename of a method between version of Apache Commons Lang

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
