### PR TITLE
Changing `NullArgumentException` to `NullPointerException` as part of Apache Commons Lang 2.x -> 3.x migration, as per recommended in their docs.

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-commons-lang-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/apache-commons-lang-2-3.yml
@@ -41,3 +41,6 @@ recipeList:
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.apache.commons.lang3.exception.ExceptionUtils getFullStackTrace(..)
       newMethodName: getStackTrace
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.commons.lang3.NullArgumentException
+      newFullyQualifiedTypeName: java.lang.NullPointerException

--- a/src/test/java/org/openrewrite/apache/commons/lang/UpgradeApacheCommonsLang_2_3Test.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/UpgradeApacheCommonsLang_2_3Test.java
@@ -100,4 +100,29 @@ class UpgradeApacheCommonsLang_2_3Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void nullArgumentExceptionChangesToNullPointerException() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.commons.lang.NullArgumentException;
+
+              class A {
+                  boolean doSomething(Throwable t) {
+                     return t instanceof NullArgumentException;
+                  }
+              }
+              """,
+            """
+              class A {
+                  boolean doSomething(Throwable t) {
+                     return t instanceof NullPointerException;
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
With the migration from Apache Commons Lang 2.x -> 3.x, `NullArgumentException` has been fully removed, in favour of using `NullPointerException`.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
