### PR TITLE
Migrating `IOReactorConfig` from HttpCore Nio 4.4.x to HttpCore 5.x

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
 
     testRuntimeOnly("org.apache.httpcomponents:httpclient:4.5.14")
     testRuntimeOnly("org.apache.httpcomponents:httpmime:4.5.14")
+    testRuntimeOnly("org.apache.httpcomponents:httpcore-nio:4.4.16")
     testRuntimeOnly("org.apache.httpcomponents.client5:httpclient5:5.2.+")
 
     testImplementation("commons-collections:commons-collections:3.2.2")

--- a/src/main/java/org/openrewrite/apache/httpclient5/ChangeArgumentToTimeValue.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/ChangeArgumentToTimeValue.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.apache.httpclient5;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class ChangeArgumentToTimeValue extends Recipe {
+    @Option(displayName = "Method pattern",
+            description = "A method pattern that is used to find matching method invocations.",
+            example = "org.apache.http.impl.nio.reactor.IOReactorConfig.Builder setSelectInterval(long)")
+    String methodPattern;
+
+    @Option(displayName = "Time unit",
+            description = "The TimeUnit enum value we want to use to turn the original value into a TimeValue. Defaults to `MILLISECONDS`.",
+            example = "MILLISECONDS",
+            required = false)
+    @Nullable
+    TimeUnit timeUnit;
+
+    @Override
+    public String getDisplayName() {
+        return "Changes an argument to a TimeValue for matched method invocations";
+    }
+
+    @Override
+    public String getDescription() {
+        return "In Apache Http Client 5.x migration, some methods that previously took a single long argument have changed to take a TimeValue. " +
+                "Previously in 4.x, all these methods were implicitly having the value expressed in milliseconds. By default this recipe uses " +
+                "`TimeUnit.MILLISECONDS` for the TimeUnit when creating a TimeValue. It is possible to specify this as a parameter. Since all " +
+                "affected methods of the Apache Http Client 5.x migration only have one long argument, the recipe applies with matched method " +
+                "invocations of exactly one parameter.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            final MethodMatcher matcher = new MethodMatcher(methodPattern);
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                if (matcher.matches(m) && m.getArguments().size() == 1) {
+                    JavaTemplate template = JavaTemplate
+                            .builder("TimeValue.of(#{any()}, TimeUnit.#{})")
+                            .contextSensitive()
+                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "httpcore5"))
+                            .imports("org.apache.hc.core5.util.TimeValue", "java.util.concurrent.TimeUnit")
+                            .build();
+                    List<Object> arguments = new ArrayList<>(m.getArguments());
+                    arguments.add(timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS);
+                    m = template.apply(
+                            updateCursor(m),
+                            m.getCoordinates().replaceArguments(),
+                            arguments.toArray(new Object[0])
+                    );
+                    maybeAddImport("org.apache.hc.core5.util.TimeValue");
+                    maybeAddImport("java.util.concurrent.TimeUnit");
+                }
+                return m;
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -52,6 +52,7 @@ recipeList:
       artifactId: httpclient5
       version: 5.4.x
       onlyIfUsing: org.apache.http.impl.client.*
+  - org.openrewrite.apache.httpclient5.UpgradeApacheHttpCore_5_NioClassMapping
   - org.openrewrite.maven.RemoveDuplicateDependencies
   - org.openrewrite.apache.httpclient5.MigrateRequestConfig
   - org.openrewrite.apache.httpclient5.UsernamePasswordCredentials
@@ -60,6 +61,42 @@ recipeList:
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit
   - org.openrewrite.apache.httpclient5.StatusLine
   - org.openrewrite.apache.httpclient5.MigrateAuthScope
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.openrewrite.apache.httpclient5.UpgradeApacheHttpCore_5_NioClassMapping
+displayName: Migrate to Apache HttpCore Nio Classes to Apache HttpCore 5.x
+description: Mapping of all the compatible classes of Apache HttpCore 5.x from Apache HttpCore Nio 4.4.x.
+recipeList:
+  - org.openrewrite.java.dependencies.ChangeDependency:
+      oldGroupId: org.apache.httpcomponents
+      oldArtifactId: httpcore-nio
+      newGroupId: org.apache.httpcomponents.core5
+      newArtifactId: httpcore5
+      newVersion: 5.3.x
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.impl.nio.reactor.IOReactorConfig
+      newFullyQualifiedTypeName: org.apache.hc.core5.reactor.IOReactorConfig
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig getShutdownGracePeriod()
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig isInterestOpQueued()
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig getConnectTimeout()
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.impl.nio.reactor.IOReactorConfig.Builder
+      newFullyQualifiedTypeName: org.apache.hc.core5.reactor.IOReactorConfig.Builder
+  - org.openrewrite.apache.httpclient5.ChangeArgumentToTimeValue:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig.Builder setSelectInterval(long)
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig.Builder setShutdownGracePeriod(long)
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig.Builder setInterestOpQueued(boolean)
+  - org.openrewrite.apache.httpclient5.AddTimeUnitArgument:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig.Builder setSoTimeout(int)
+  - org.openrewrite.apache.httpclient5.AddTimeUnitArgument:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig.Builder setSoLinger(int)
+  - org.openrewrite.java.RemoveMethodInvocations:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig.Builder setConnectTimeout(int)
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -76,10 +76,19 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.http.impl.nio.reactor.IOReactorConfig
       newFullyQualifiedTypeName: org.apache.hc.core5.reactor.IOReactorConfig
+  - org.openrewrite.java.ChangeMethodInvocationReturnType:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig getSelectInterval()
+      newReturnType: org.apache.hc.core5.util.TimeValue
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: org.apache.hc.core5.reactor.IOReactorConfig getShutdownGracePeriod()
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: org.apache.hc.core5.reactor.IOReactorConfig isInterestOpQueued()
+  - org.openrewrite.java.ChangeMethodInvocationReturnType:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig getSoTimeout()
+      newReturnType: org.apache.hc.core5.util.Timeout
+  - org.openrewrite.java.ChangeMethodInvocationReturnType:
+      methodPattern: org.apache.hc.core5.reactor.IOReactorConfig getSoLinger()
+      newReturnType: org.apache.hc.core5.util.TimeValue
   - org.openrewrite.java.RemoveMethodInvocations:
       methodPattern: org.apache.hc.core5.reactor.IOReactorConfig getConnectTimeout()
   - org.openrewrite.java.ChangeType:

--- a/src/test/java/org/openrewrite/apache/httpclient5/ChangeArgumentToTimeValueTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/ChangeArgumentToTimeValueTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.apache.httpclient5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpecs;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.openrewrite.java.Assertions.java;
+
+class ChangeArgumentToTimeValueTest implements RewriteTest {
+    //language=java
+    private static final SourceSpecs stubCode = java(
+      """
+        import org.apache.hc.core5.util.TimeValue;
+
+        class A {
+            private TimeValue storedValue;
+
+            void method(long value) {
+                storedValue = TimeValue.ofMilliseconds(value);
+            }
+
+            void method(TimeValue value) {
+                storedValue = value;
+            }
+        }
+        """
+    );
+
+    @Test
+    void changeArgumentToTimeValueDefaultMilliseconds() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeArgumentToTimeValue("A method(long)", null)),
+          stubCode,
+          //language=java
+          java(
+            """
+              class B {
+                  void test() {
+                      A a = new A();
+                      a.method(100);
+                  }
+              }
+              """,
+            """
+              import org.apache.hc.core5.util.TimeValue;
+
+              import java.util.concurrent.TimeUnit;
+
+              class B {
+                  void test() {
+                      A a = new A();
+                      a.method(TimeValue.of(100, TimeUnit.MILLISECONDS));
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeArgumentToTimeValueWithTimeUnitProvided() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeArgumentToTimeValue("A method(long)", TimeUnit.SECONDS)),
+          stubCode,
+          //language=java
+          java(
+            """
+              class B {
+                  void test() {
+                      A a = new A();
+                      a.method(100);
+                  }
+              }
+              """,
+            """
+              import org.apache.hc.core5.util.TimeValue;
+
+              import java.util.concurrent.TimeUnit;
+
+              class B {
+                  void test() {
+                      A a = new A();
+                      a.method(TimeValue.of(100, TimeUnit.SECONDS));
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateApacheHttpCoreNioTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateApacheHttpCoreNioTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.apache.httpclient5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class MigrateApacheHttpCoreNioTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec
+          .parser(JavaParser.fromJavaVersion().classpath("httpcore", "httpcore-nio", "httpcore5"))
+          .recipeFromResources("org.openrewrite.apache.httpclient5.UpgradeApacheHttpCore_5_NioClassMapping");
+    }
+
+    @Test
+    @DocumentExample
+    void migratesIOReactorConfig() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.http.impl.nio.reactor.IOReactorConfig;
+              import org.apache.http.impl.nio.reactor.IOReactorConfig.Builder;
+
+              class A {
+                  void method() {
+                      IOReactorConfig.Builder builder = new IOReactorConfig.Builder();
+                      builder.setSelectInterval(500);
+                      builder.setShutdownGracePeriod(400);
+                      builder.setInterestOpQueued(true);
+                      builder.setSoTimeout(300);
+                      builder.setSoLinger(200);
+                      builder.setConnectTimeout(100);
+                      IOReactorConfig ioReactorConfig = builder.build();
+                      ioReactorConfig.getShutdownGracePeriod();
+                      ioReactorConfig.isInterestOpQueued();
+                      ioReactorConfig.getConnectTimeout();
+                  }
+              }
+              """,
+            """
+              import org.apache.hc.core5.reactor.IOReactorConfig;
+              import org.apache.hc.core5.reactor.IOReactorConfig.Builder;
+              import org.apache.hc.core5.util.TimeValue;
+
+              import java.util.concurrent.TimeUnit;
+
+              class A {
+                  void method() {
+                      IOReactorConfig.Builder builder = new IOReactorConfig.Builder();
+                      builder.setSelectInterval(TimeValue.of(500, TimeUnit.MILLISECONDS));
+                      builder.setSoTimeout(300, TimeUnit.MILLISECONDS);
+                      builder.setSoLinger(200, TimeUnit.MILLISECONDS);
+                      IOReactorConfig ioReactorConfig = builder.build();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migrateDependencies() {
+        rewriteRun(
+          pomXml(
+            //language=xml
+            """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>org.example</groupId>
+                  <artifactId>example</artifactId>
+                  <version>1.0.0</version>
+                  <dependencies>
+                      <dependency>
+                          <groupId>org.apache.httpcomponents</groupId>
+                          <artifactId>httpcore-nio</artifactId>
+                          <version>4.4.16</version>
+                      </dependency>
+                  </dependencies>
+              </project>
+              """,
+            spec -> spec.after(pom -> {
+                Matcher version = Pattern.compile("5\\.3\\.\\d+").matcher(pom);
+                assertThat(version.find()).describedAs("Expected 5.3.x in %s", pom).isTrue();
+                //language=xml
+                return """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>org.example</groupId>
+                      <artifactId>example</artifactId>
+                      <version>1.0.0</version>
+                      <dependencies>
+                          <dependency>
+                              <groupId>org.apache.httpcomponents.core5</groupId>
+                              <artifactId>httpcore5</artifactId>
+                              <version>%s</version>
+                          </dependency>
+                      </dependencies>
+                  </project>
+                  """.formatted(version.group(0));
+            })
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateApacheHttpCoreNioTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateApacheHttpCoreNioTest.java
@@ -56,8 +56,11 @@ class MigrateApacheHttpCoreNioTest implements RewriteTest {
                       builder.setSoLinger(200);
                       builder.setConnectTimeout(100);
                       IOReactorConfig ioReactorConfig = builder.build();
+                      long selectInterval = ioReactorConfig.getSelectInterval();
                       ioReactorConfig.getShutdownGracePeriod();
                       ioReactorConfig.isInterestOpQueued();
+                      int soTimeout = ioReactorConfig.getSoTimeout();
+                      int soLinger = ioReactorConfig.getSoLinger();
                       ioReactorConfig.getConnectTimeout();
                   }
               }
@@ -66,6 +69,7 @@ class MigrateApacheHttpCoreNioTest implements RewriteTest {
               import org.apache.hc.core5.reactor.IOReactorConfig;
               import org.apache.hc.core5.reactor.IOReactorConfig.Builder;
               import org.apache.hc.core5.util.TimeValue;
+              import org.apache.hc.core5.util.Timeout;
 
               import java.util.concurrent.TimeUnit;
 
@@ -76,6 +80,9 @@ class MigrateApacheHttpCoreNioTest implements RewriteTest {
                       builder.setSoTimeout(300, TimeUnit.MILLISECONDS);
                       builder.setSoLinger(200, TimeUnit.MILLISECONDS);
                       IOReactorConfig ioReactorConfig = builder.build();
+                      TimeValue selectInterval = ioReactorConfig.getSelectInterval();
+                      Timeout soTimeout = ioReactorConfig.getSoTimeout();
+                      TimeValue soLinger = ioReactorConfig.getSoLinger();
                   }
               }
               """


### PR DESCRIPTION
For the Apache Http Components 4.x -> 5.x migration, `org.apache.http.impl.nio.reactor.IOReactorConfig` (within `httpcore-nio`) is getting migrated to `org.apache.hc.core5.http.impl.nio.reactor.IOReactorConfig` whereas it should be migrated to `org.apache.hc.core5.reactor.IOReactorConfig` (within `httpcore5`)

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
