### PR TITLE
Fixing edge case where none of the parent `...entity` package had been migrated at all (parent doesn't recursively migrate package for safety, as it's in another dependency)

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -279,7 +279,13 @@ recipeList:
       oldPackageName: org.apache.http.entity
       newPackageName: org.apache.hc.core5.http.io.entity
   - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.entity.mime
+      newPackageName: org.apache.hc.client5.http.entity.mime
+  - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.hc.core5.http.io.entity.mime
+      newPackageName: org.apache.hc.client5.http.entity.mime
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.entity.mime.content
       newPackageName: org.apache.hc.client5.http.entity.mime
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.hc.client5.http.entity.mime.content

--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -96,6 +96,29 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
     }
 
     @Test
+    void ensureEntityMimeAloneMigrated() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.http.entity.mime.MultipartEntityBuilder;
+
+              class A {
+                  MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+              }
+              """,
+            """
+              import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
+
+              class A {
+                  MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void doesNotMigrateAlreadyCorrectPackage() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What's changed?
Added additional `ChangePackage` calls to cover the cases where your file hasn't used the `org.apache.http.entity` package at all, and instead only used `org.apache.http.entity.mime` or below.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
