### PR TITLE
Prevent changing of `org.apache.http.params` package (as there's no generic migration possible) and add a comment to that effect

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-4-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-4-5.yml
@@ -21,7 +21,7 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient4.UpgradeApacheHttpClient_4_5
 displayName: Migrates to ApacheHttpClient 4.5.x
 description: >-
-  Migrate applications to the latest Apache HttpClient 4.5.x release. This recipe modifies 
+  Migrate applications to the latest Apache HttpClient 4.5.x release. This recipe modifies
   application's build files, make changes to deprecated/preferred APIs, and migrates configuration settings that have
   changes between versions.
 tags:

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -545,6 +545,13 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http
       newPackageName: org.apache.hc.core5.http
+  # Change package back because there's no direct migration
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.hc.core5.http.params
+      newPackageName: org.apache.http.params
+  - org.openrewrite.java.AddCommentToImport:
+      comment: "No generic migration for classes in the `org.apache.http.params` package exists, please migrate manually"
+      typePattern: org.apache.http.params..*
   # Fixing specific mappings
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.RequestLine

--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -96,6 +96,26 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
     }
 
     @Test
+    void preventsChangingOfParamsPackageAndAddsNotice() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.http.HttpEntity;
+              import org.apache.http.params.HttpParams;
+              class A {}
+              """,
+            """
+              import org.apache.hc.core5.http.HttpEntity;
+              /* No generic migration for classes in the `org.apache.http.params` package exists, please migrate manually */
+              import org.apache.http.params.HttpParams;
+              class A {}
+              """
+          )
+        );
+    }
+
+    @Test
     void ensureEntityMimeAloneMigrated() {
         rewriteRun(
           //language=java
@@ -756,8 +776,8 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                       """
                   )
                 ),
-                //language=xml
                 pomXml(
+                  //language=xml
                   """
                     <project>
                         <modelVersion>4.0.0</modelVersion>
@@ -777,6 +797,7 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                       Matcher version = Pattern.compile("5\\.4\\.\\d+").matcher(pom);
                       assertThat(version.find()).describedAs("Expected 5.4.x in %s", pom).isTrue();
                       String httpClientVersion = version.group();
+                      //language=xml
                       return """
                         <project>
                             <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## What's changed?
Prevented changing of the `org.apache.http.params` package and added a comment to the first relevant import indicating that manual migration will be necessary.

## What's your motivation?
`org.apache.http.params.HttpParams`, along with all other classes in the `org.apache.http.params` package have been deprecated since at least version `4.3` of the Apache Http Client library (seen [here](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/params/package-summary.html)). In their stead, there are a number of configuration classes that would be used instead, but they are context specific to what content was being put into the `HttpParams` instance and can't be easily adequately inferred in many usages from a single codebase. Since we can't migrate it, it would be best to prevent the package being changed so it can more easily be found through manual effort. This PR prevents the package from change and also adds a comment suggesting that a manual change must be undertaken, as we cannot automatically migrate it.

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
