### PR TITLE
Migrate `org.apache.http.HttpResponse` to `org.apache.hc.core5.http.ClassicHttpResponse`

### DIFF
--- a/src/main/java/org/openrewrite/apache/httpclient5/NewRequestLine.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/NewRequestLine.java
@@ -39,14 +39,14 @@ public class NewRequestLine extends Recipe {
 
     @Override
     public String getDescription() {
-        return "`HttpRequestBase::getStatusLine()` was removed in 5.x when `HttpRequestBase` was migrated to `HttpUriRequestBase`, " +
+        return "`HttpRequestBase::getStatusLine()` was deprecated in 4.x, " +
                 "so we replace it with `new RequestLine(HttpRequest)`. " +
                 "Ideally we will try to simply method chains for `getMethod`, `getUri` and `getProtocolVersion`, " +
                 "but there are some scenarios where `RequestLine` object is assigned or used directly, and we need to " +
                 "instantiate the object.";
     }
 
-    private static final MethodMatcher MATCHER = new MethodMatcher("org.apache.hc.client5.http.classic.methods.HttpUriRequestBase getRequestLine()");
+    private static final MethodMatcher MATCHER = new MethodMatcher("org.apache.http.client.methods.HttpRequestBase getRequestLine()");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/src/main/java/org/openrewrite/apache/httpclient5/NewStatusLine.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/NewStatusLine.java
@@ -45,7 +45,7 @@ public class NewStatusLine extends Recipe {
                 "instantiate the object.";
     }
 
-    private static final MethodMatcher MATCHER = new MethodMatcher("org.apache.hc.core5.http.HttpResponse getStatusLine()");
+    private static final MethodMatcher MATCHER = new MethodMatcher("org.apache.http.HttpResponse getStatusLine()");
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -635,6 +635,15 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpConnectionFactory
       newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.HttpRequest
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpRequest
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.HttpResponse
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpResponse
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.client.ResponseHandler
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpClientResponseHandler
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http
@@ -665,15 +674,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.HttpConnectionFactory
       newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.http.HttpRequest
-      newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpRequest
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.http.HttpResponse
-      newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpResponse
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.http.client.ResponseHandler
-      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpClientResponseHandler
 
   # Fixing argument order change
   - org.openrewrite.java.ReorderMethodArguments:

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -34,10 +34,11 @@ recipeList:
   - org.openrewrite.maven.RemoveDuplicateDependencies
   - org.openrewrite.apache.httpclient5.MigrateRequestConfig
   - org.openrewrite.apache.httpclient5.UsernamePasswordCredentials
+  - org.openrewrite.apache.httpclient5.StatusLine
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit
-  - org.openrewrite.apache.httpclient5.StatusLine
+  - org.openrewrite.apache.httpclient5.NewRequestLine
   - org.openrewrite.apache.httpclient5.MigrateAuthScope
   - org.openrewrite.apache.httpclient5.MigrateSSLConnectionSocketFactory
   - org.openrewrite.java.DeleteMethodArgument:
@@ -736,16 +737,15 @@ displayName: Migrate to ApacheHttpClient 5.x deprecated methods from 4.x
 description: Migrates deprecated methods to their equivalent ones in 5.x
 recipeList:
   - org.openrewrite.java.SimplifyMethodChain:
-      methodPatternChain: ['org.apache.hc.core5.http.HttpResponse getStatusLine()', 'org.apache.hc.core5.http.message.StatusLine getStatusCode()']
+      methodPatternChain: ['org.apache.http.HttpResponse getStatusLine()', 'org.apache.http.StatusLine getStatusCode()']
       newMethodName: getCode
   - org.openrewrite.java.SimplifyMethodChain:
-      methodPatternChain: ['org.apache.hc.core5.http.HttpResponse getStatusLine()', 'org.apache.hc.core5.http.message.StatusLine getReasonPhrase()']
+      methodPatternChain: ['org.apache.http.HttpResponse getStatusLine()', 'org.apache.http.StatusLine getReasonPhrase()']
       newMethodName: getReasonPhrase
   - org.openrewrite.java.SimplifyMethodChain:
-      methodPatternChain: [ 'org.apache.hc.core5.http.HttpResponse getStatusLine()', 'org.apache.hc.core5.http.message.StatusLine getProtocolVersion()' ]
+      methodPatternChain: [ 'org.apache.http.HttpResponse getStatusLine()', 'org.apache.http.StatusLine getProtocolVersion()' ]
       newMethodName: getVersion
   - org.openrewrite.apache.httpclient5.NewStatusLine
-  - org.openrewrite.apache.httpclient5.NewRequestLine
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.CredentialsStoreSetCredentials

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -38,7 +38,6 @@ recipeList:
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_DeprecatedMethods
   - org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_TimeUnit
-  - org.openrewrite.apache.httpclient5.NewRequestLine
   - org.openrewrite.apache.httpclient5.MigrateAuthScope
   - org.openrewrite.apache.httpclient5.MigrateSSLConnectionSocketFactory
   - org.openrewrite.java.DeleteMethodArgument:
@@ -636,6 +635,8 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.HttpConnectionFactory
       newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpConnectionFactory
+
+  # Fixing specific mappings for core Http interfaces
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.http.HttpRequest
       newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpRequest
@@ -746,6 +747,7 @@ recipeList:
       methodPatternChain: [ 'org.apache.http.HttpResponse getStatusLine()', 'org.apache.http.StatusLine getProtocolVersion()' ]
       newMethodName: getVersion
   - org.openrewrite.apache.httpclient5.NewStatusLine
+  - org.openrewrite.apache.httpclient5.NewRequestLine
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.openrewrite.apache.httpclient5.CredentialsStoreSetCredentials

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
@@ -24,7 +24,7 @@ import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.java;
 
-public class MigrateHttpResponseTest implements RewriteTest {
+class MigrateHttpResponseTest implements RewriteTest {
     @Override
     public void defaults(RecipeSpec spec) {
         spec.parser(JavaParser.fromJavaVersion()

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
@@ -1,0 +1,112 @@
+package org.openrewrite.apache.httpclient5;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.java.Assertions.java;
+
+public class MigrateHttpResponseTest implements RewriteTest {
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JavaParser.fromJavaVersion()
+            .classpathFromResources(new InMemoryExecutionContext(),
+              "httpclient-4", "httpcore-4",
+              "httpclient5", "httpcore5"))
+          .recipeFromResources("org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5");
+    }
+
+    @DocumentExample
+    @Test
+    void migratesHttpResponseToClassicHttpResponse() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.http.HttpEntity;
+              import org.apache.http.HttpResponse;
+              import org.apache.http.client.methods.HttpGet;
+              import org.apache.http.impl.client.CloseableHttpClient;
+              import org.apache.http.impl.client.HttpClients;
+
+              import java.io.IOException;
+
+              class HttpClientManager {
+                  void getEntity() throws IOException {
+                      CloseableHttpClient httpClient = HttpClients.createDefault();
+                      HttpGet httpGet = new HttpGet("https://example.com");
+                      HttpResponse response = httpClient.execute(httpGet);
+                      HttpEntity entity = response.getEntity();
+                  }
+              }
+              """,
+            """
+              import org.apache.hc.core5.http.ClassicHttpResponse;
+              import org.apache.hc.core5.http.HttpEntity;
+              import org.apache.hc.client5.http.classic.methods.HttpGet;
+              import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+              import org.apache.hc.client5.http.impl.classic.HttpClients;
+
+              import java.io.IOException;
+
+              class HttpClientManager {
+                  void getEntity() throws IOException {
+                      CloseableHttpClient httpClient = HttpClients.createDefault();
+                      HttpGet httpGet = new HttpGet("https://example.com");
+                      ClassicHttpResponse response = httpClient.execute(httpGet);
+                      HttpEntity entity = response.getEntity();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migratesCloseableHttpResponse() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import org.apache.http.HttpEntity;
+              import org.apache.http.client.methods.CloseableHttpResponse;
+              import org.apache.http.client.methods.HttpGet;
+              import org.apache.http.impl.client.CloseableHttpClient;
+              import org.apache.http.impl.client.HttpClients;
+
+              import java.io.IOException;
+
+              class HttpClientManager {
+                  void getEntity() throws IOException {
+                      CloseableHttpClient httpClient = HttpClients.createDefault();
+                      HttpGet httpGet = new HttpGet("https://example.com");
+                      CloseableHttpResponse response = httpClient.execute(httpGet);
+                      HttpEntity entity = response.getEntity();
+                  }
+              }
+              """,
+            """
+              import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+              import org.apache.hc.core5.http.HttpEntity;
+              import org.apache.hc.client5.http.classic.methods.HttpGet;
+              import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+              import org.apache.hc.client5.http.impl.classic.HttpClients;
+
+              import java.io.IOException;
+
+              class HttpClientManager {
+                  void getEntity() throws IOException {
+                      CloseableHttpClient httpClient = HttpClients.createDefault();
+                      HttpGet httpGet = new HttpGet("https://example.com");
+                      CloseableHttpResponse response = httpClient.execute(httpGet);
+                      HttpEntity entity = response.getEntity();
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.openrewrite.apache.httpclient5;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/openrewrite/apache/httpclient5/NewRequestLineTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/NewRequestLineTest.java
@@ -55,8 +55,8 @@ class NewRequestLineTest implements RewriteTest {
               """,
             """
               import org.apache.hc.client5.http.classic.methods.HttpGet;
-              import org.apache.hc.core5.http.ProtocolVersion;
               import org.apache.hc.core5.http.message.RequestLine;
+              import org.apache.hc.core5.http.ProtocolVersion;
 
               class A {
                   void method() {

--- a/src/test/java/org/openrewrite/apache/httpclient5/NewStatusLineTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/NewStatusLineTest.java
@@ -41,11 +41,11 @@ class NewStatusLineTest implements RewriteTest {
           java(
             """
               import org.apache.http.HttpStatus;
+              import org.apache.http.ProtocolVersion;
               import org.apache.http.client.methods.CloseableHttpResponse;
               import org.apache.http.client.methods.HttpGet;
               import org.apache.http.impl.client.CloseableHttpClient;
               import org.apache.http.impl.client.HttpClientBuilder;
-              import org.apache.http.ProtocolVersion;
 
               import java.io.IOException;
 
@@ -66,10 +66,10 @@ class NewStatusLineTest implements RewriteTest {
               import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
               import org.apache.hc.core5.http.message.StatusLine;
               import org.apache.hc.core5.http.HttpStatus;
+              import org.apache.hc.core5.http.ProtocolVersion;
               import org.apache.hc.client5.http.classic.methods.HttpGet;
               import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
               import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
-              import org.apache.hc.core5.http.ProtocolVersion;
 
               import java.io.IOException;
 

--- a/src/test/java/org/openrewrite/apache/httpclient5/NewStatusLineTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/NewStatusLineTest.java
@@ -64,12 +64,12 @@ class NewStatusLineTest implements RewriteTest {
               """,
             """
               import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+              import org.apache.hc.core5.http.message.StatusLine;
               import org.apache.hc.core5.http.HttpStatus;
               import org.apache.hc.client5.http.classic.methods.HttpGet;
               import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
               import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
               import org.apache.hc.core5.http.ProtocolVersion;
-              import org.apache.hc.core5.http.message.StatusLine;
 
               import java.io.IOException;
 


### PR DESCRIPTION
## What's changed?

The `org.apache.http.HttpResponse` in HttpClient 4.x needs to be migrated to `org.apache.hc.core5.http.ClassicHttpResponse` in HttpClient 5.x. The `ClassicHttpResponse` provides some backward-compatibility to the HttpClient 4.x API.

We already wanted to make that switch in our recipe list via

```
- org.openrewrite.java.ChangeType:
    oldFullyQualifiedTypeName: org.apache.http.HttpRequest
    newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpRequest
- org.openrewrite.java.ChangeType:
    oldFullyQualifiedTypeName: org.apache.http.HttpResponse
    newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpResponse
- org.openrewrite.java.ChangeType:
    oldFullyQualifiedTypeName: org.apache.http.client.ResponseHandler
    newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpClientResponseHandler
```

but that was listed after 

```
- org.openrewrite.java.ChangePackage:
    oldPackageName: org.apache.http
    newPackageName: org.apache.hc.core5.http
```

so it didn't have any more effect as `org.apache.http.HttpResponse` was already changed to `org.apache.hc.core5.http.HttpResponse`.

## What's your motivation?

The recipe used to change [org.apache.http.HttpResponse](https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpResponse.html) to [org.apache.hc.core5.http.HttpResponse](https://hc.apache.org/httpcomponents-core-5.3.x/current/httpcore5/apidocs/org/apache/hc/core5/http/HttpResponse.html) via the following rule:

```
- org.openrewrite.java.ChangePackage:
    oldPackageName: org.apache.http
    newPackageName: org.apache.hc.core5.http
```

The new class doesn't provide the method `getEntity()` anymore. It has been moved to [HttpEntityContainer#getEntity()](https://hc.apache.org/httpcomponents-core-5.3.x/current/apidocs/org/apache/hc/core5/http/HttpEntityContainer.html#getEntity--). Accessing the entity requires a `ClassicHttpResponse` or `ClosableHttpResponse`.

As a result the end user experiences a compilation issues, as the method cannot be resolved.

## Anything in particular you'd like reviewers to focus on?

Given the changed order of execution in the long list of recipes had an impact on other recipes, namely `NewStatusLine` and `NewRequestLine`. The description of `NewStatusLine` says that it works based on the HttpClient 4.x API so the method matcher needs to run before `org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping`. The `NewRequestLine` changes a HttpClient 5.x API so it needs to run after `org.openrewrite.apache.httpclient5.UpgradeApacheHttpClient_5_ClassMapping`.

I noticed that we sometimes conflate recipes for HttpClient 4.x to HttpClient 5.x migration with changes that _just_ apply to the HttpClient 5.x API but aims to fix deprecated APIs. Would it make sense to separate those concerns?