### PR TITLE
Add `StringJoinSeparatorIterableCharSequence` recipe and tests

### DIFF
--- a/src/main/java/org/openrewrite/apache/commons/lang/ApacheCommonsStringUtils.java
+++ b/src/main/java/org/openrewrite/apache/commons/lang/ApacheCommonsStringUtils.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.openrewrite.java.template.Matches;
 import org.openrewrite.java.template.RecipeDescriptor;
 
+import java.util.Iterator;
 import java.util.Objects;
 
 @SuppressWarnings("ALL")
@@ -333,6 +334,22 @@ public class ApacheCommonsStringUtils {
     //        return (s == null ? null : String.join("", s));
     //    }
     //}
+
+    @RecipeDescriptor(
+        name = "Replace `StringUtils.join(Iterable<? extends CharSequence>, String)` with JDK provided API",
+        description = "Replace Apache Commons `StringUtils.join(Iterable<? extends CharSequence> iterable, String separator)` with JDK provided API."
+    )
+    public static class StringJoinSeparatorIterableCharSequence {
+        @BeforeTemplate
+        String before(Iterable<? extends CharSequence> iterable, String separator) {
+            return StringUtils.join(iterable, separator);
+        }
+
+        @AfterTemplate
+        String after(Iterable<? extends CharSequence> iterable, String separator) {
+            return String.join(separator, iterable);
+        }
+    }
 
     // NOTE: not sure if accurate replacement
     @RecipeDescriptor(

--- a/src/main/java/org/openrewrite/apache/commons/lang/ApacheCommonsStringUtils.java
+++ b/src/main/java/org/openrewrite/apache/commons/lang/ApacheCommonsStringUtils.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.openrewrite.java.template.Matches;
 import org.openrewrite.java.template.RecipeDescriptor;
 
-import java.util.Iterator;
 import java.util.Objects;
 
 @SuppressWarnings("ALL")

--- a/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsStringUtilsTest.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/ApacheCommonsStringUtilsTest.java
@@ -341,6 +341,93 @@ class ApacheCommonsStringUtilsTest implements RewriteTest {
     }
 
     @Nested
+    class StringJoinSeparatorIterableCharSequenceTests {
+        @Test
+        void stringJoinWithIterable() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.apache.commons.lang3.StringUtils;
+                  import java.util.List;
+
+                  class Foo {
+                      String test(List<String> items) {
+                          return StringUtils.join(items, ", ");
+                      }
+                  }
+                  """,
+                """
+                  import java.util.List;
+
+                  class Foo {
+                      String test(List<String> items) {
+                          return String.join(", ", items);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void stringJoinWithIterableAndNullSeparator() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.apache.commons.lang3.StringUtils;
+                  import java.util.List;
+
+                  class Foo {
+                      String test(List<String> items) {
+                          return StringUtils.join(items, null);
+                      }
+                  }
+                  """,
+                """
+                  import java.util.List;
+
+                  class Foo {
+                      String test(List<String> items) {
+                          return String.join(null, items);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void stringJoinWithIterableSubtype() {
+            rewriteRun(
+              //language=java
+              java(
+                """
+                  import org.apache.commons.lang3.StringUtils;
+                  import java.util.Set;
+
+                  class Foo {
+                      String test(Set<CharSequence> items) {
+                          return StringUtils.join(items, "-");
+                      }
+                  }
+                  """,
+                """
+                  import java.util.Set;
+
+                  class Foo {
+                      String test(Set<CharSequence> items) {
+                          return String.join("-", items);
+                      }
+                  }
+                  """
+              )
+            );
+        }
+    }
+
+    @Nested
     class RemoveRedundantNullCheckWithIsNotBlankTests {
         @Test
         void removeRedundantNullCheckWithIsNotBlank() {


### PR DESCRIPTION
## Summary
- Added `StringJoinSeparatorIterableCharSequence` recipe to replace `StringUtils.join(Iterable, String)` with JDK's `String.join()`
- Added comprehensive unit tests covering various scenarios

## Test plan
- [x] Test basic conversion with `List<String>`
- [x] Test handling of null separator
- [x] Test with `Set<CharSequence>` to verify it works with Iterable subtypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)