### PR TITLE
Removing the `org.apache.httpcomponents:httpasyncclient` dependency (not compatible with Apache HttpClient 5.x), fixing a specific missed request class's migration, and handling one of the `HttpAsyncClient` dependency's packages to map to the `HttpClient` new package.

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -76,6 +76,9 @@ recipeList:
   - org.openrewrite.java.dependencies.RemoveDependency:
       groupId: org.apache.httpcomponents
       artifactId: httpcore
+  - org.openrewrite.java.dependencies.RemoveDependency:
+      groupId: org.apache.httpcomponents
+      artifactId: httpasyncclient
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -246,6 +249,9 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.classic.methods.CloseableHttpResponse
       newFullyQualifiedTypeName: org.apache.hc.client5.http.impl.classic.CloseableHttpResponse
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.hc.client5.http.classic.methods.HttpEntityEnclosingRequestBase
+      newFullyQualifiedTypeName: org.apache.hc.client5.http.classic.methods.HttpUriRequestBase
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.hc.client5.http.classic.methods.HttpRequestBase
       newFullyQualifiedTypeName: org.apache.hc.client5.http.classic.methods.HttpUriRequestBase
@@ -511,6 +517,9 @@ recipeList:
       oldFullyQualifiedTypeName: org.apache.hc.core5.http.config.SocketConfig.Builder
       newFullyQualifiedTypeName: org.apache.hc.core5.http.io.SocketConfig.Builder
 
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.http.impl.nio.client
+      newPackageName: org.apache.hc.client5.http.impl.async
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.impl
       newPackageName: org.apache.hc.core5.http.impl.io


### PR DESCRIPTION
## What's changed?
Dealing with some of the usage of `org.apache.httpcomponents:httpasyncclient` dependency that was EOL'd with 5.x of Apache HttpClient and fixing a missed class migration for on of the old http request classes.

## What's your motivation?
Previously mapped packages were incorrect and breaking compilation

### Checklist
- [X] I've added unit tests to cover both positive and negative cases
- [X] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [X] I've used the IntelliJ IDEA auto-formatter on affected files
