### PR TITLE
Enable migrateTransitiveParent test for HttpClient 5 upgrade

### DIFF
--- a/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/UpgradeApacheHttpClient5Test.java
@@ -15,7 +15,6 @@
  */
 package org.openrewrite.apache.httpclient5;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
@@ -943,7 +942,6 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
               ));
         }
 
-        @Disabled("`org.openrewrite.java.dependencies.DependencyInsight` does not consider transitive dependencies from parent")
         @Test
         void migrateTransitiveParent() {
             rewriteRun(
@@ -979,6 +977,29 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                 )
               ),
               mavenProject("child",
+                srcMainJava(
+                  //language=java
+                  java(
+                    """
+                      import org.apache.http.impl.client.CloseableHttpClient;
+                      import org.apache.http.impl.client.HttpClients;
+                      public class A {
+                          CloseableHttpClient getClient() {
+                              return HttpClients.createDefault();
+                          }
+                      }
+                      """,
+                    """
+                      import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+                      import org.apache.hc.client5.http.impl.classic.HttpClients;
+                      public class A {
+                          CloseableHttpClient getClient() {
+                              return HttpClients.createDefault();
+                          }
+                      }
+                      """
+                  )
+                ),
                 pomXml(
                   //language=xml
                   """
@@ -995,33 +1016,10 @@ class UpgradeApacheHttpClient5Test implements RewriteTest {
                         </parent>
                     </project>
                     """,
-                  spec -> spec.after(pom -> {
-                      Matcher version = Pattern.compile("5\\.4+\\.\\d+").matcher(pom);
-                      assertThat(version.find()).describedAs("Expected 5.4.x in %s", pom).isTrue();
-                      String httpClientVersion = version.group();
-                      //language=xml
-                      return """
-                        <project>
-                            <modelVersion>4.0.0</modelVersion>
-                            <groupId>org.example</groupId>
-                            <artifactId>example</artifactId>
-                            <version>1.0.0</version>
-                            <parent>
-                                <groupId>org.example</groupId>
-                                <artifactId>parent</artifactId>
-                                <version>1.0.0</version>
-                                <relativePath>../pom.xml</relativePath>
-                            </parent>
-                            <dependencies>
-                                <dependency>
-                                    <groupId>org.apache.httpcomponents.client5</groupId>
-                                    <artifactId>httpclient5</artifactId>
-                                    <version>%s</version>
-                                </dependency>
-                            </dependencies>
-                        </project>
-                        """.formatted(httpClientVersion);
-                  })
+                  spec -> spec.after(pom -> assertThat(pom)
+                    .contains("<artifactId>httpclient5</artifactId>")
+                    .containsPattern("<version>5\\.4\\.\\d+</version>")
+                    .actual())
                 )
               )
             );


### PR DESCRIPTION
## Summary
- Enable the `@Disabled` `migrateTransitiveParent` test in `UpgradeApacheHttpClient5Test`
- The test was disabled blaming `DependencyInsight` for not considering transitive parent dependencies, but the actual issue was that the child module had no Java source files — so `AddDependency`'s `onlyIfUsing: org.apache.http..*` gate never triggered
- Add Java source files using old Apache HTTP types (`CloseableHttpClient`, `HttpClients`) to the child module, with before/after expectations for the migration
- Simplify POM assertion to use `assertThat(pom).contains(...).containsPattern(...).actual()` pattern

- Relates to #35

## Test plan
- [x] `migrateTransitiveParent` test passes
- [x] Full `UpgradeApacheHttpClient5Test` suite passes