### PR TITLE
Fix ResponseHandler migration to land in core5, not client5

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -510,6 +510,9 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.http.client.CredentialsProvider
       newFullyQualifiedTypeName: org.apache.hc.client5.http.auth.CredentialsProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.http.client.ResponseHandler
+      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpClientResponseHandler
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http.client
@@ -688,9 +691,6 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.apache.http.HttpResponse
       newFullyQualifiedTypeName: org.apache.hc.core5.http.ClassicHttpResponse
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.apache.http.client.ResponseHandler
-      newFullyQualifiedTypeName: org.apache.hc.core5.http.io.HttpClientResponseHandler
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.http

--- a/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/MigrateHttpResponseTest.java
@@ -124,4 +124,50 @@ class MigrateHttpResponseTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void migratesResponseHandlerToHttpClientResponseHandler() {
+        rewriteRun(
+          //language=java
+          java(
+            """
+              import java.io.IOException;
+              import java.nio.charset.Charset;
+
+              import org.apache.http.HttpEntity;
+              import org.apache.http.HttpResponse;
+              import org.apache.http.client.ClientProtocolException;
+              import org.apache.http.util.EntityUtils;
+              import org.apache.http.client.ResponseHandler;
+
+              public class StringResponseHandler implements ResponseHandler<String> {
+                  private static final String DEFAULT_CHAR_SET = "UTF-8";
+                  public String handleResponse(
+                          final HttpResponse response) throws IOException {
+                      HttpEntity entity = response.getEntity();
+                      return entity == null ? null : EntityUtils.toString(entity, Charset.forName(DEFAULT_CHAR_SET));
+                  }
+              }
+              """,
+            """
+              import java.io.IOException;
+              import java.nio.charset.Charset;
+              import org.apache.hc.core5.http.ClassicHttpResponse;
+              import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+              import org.apache.hc.core5.http.io.entity.EntityUtils;
+              import org.apache.hc.core5.http.HttpEntity;
+              import org.apache.hc.client5.http.ClientProtocolException;
+
+              public class StringResponseHandler implements HttpClientResponseHandler<String> {
+                  private static final String DEFAULT_CHAR_SET = "UTF-8";
+                  public String handleResponse(
+                          final ClassicHttpResponse response) throws IOException {
+                      HttpEntity entity = response.getEntity();
+                      return entity == null ? null : EntityUtils.toString(entity, Charset.forName(DEFAULT_CHAR_SET));
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`UpgradeApacheHttpClient_5_ClassMapping` was mis-mapping `org.apache.http.client.ResponseHandler`. It ended up at `org.apache.hc.client5.http.ResponseHandler` — a type that doesn't exist in HttpClient 5. The correct target is `org.apache.hc.core5.http.io.HttpClientResponseHandler` (note the `core5` module).

The recipe already had an explicit `ChangeType` for this, but it was ordered *after* the wholesale `org.apache.http.client` → `org.apache.hc.client5.http` `ChangePackage`. By the time the explicit mapping ran, the FQN had already been rewritten and no longer matched, so the fix never fired.

This PR moves the `ResponseHandler` `ChangeType` ahead of the wholesale rename so the original HttpClient 4 FQN is still matchable, and removes the now-redundant duplicate further down. Adds a regression test (alongside the existing `HttpResponse` migration tests) modeled on a real-world `implements ResponseHandler<String>` shape, which covers both the import rewrite and the `handleResponse(HttpResponse)` parameter type rewrite to `ClassicHttpResponse`.