### PR TITLE
Set commentCharacter on @CsvSource to avoid clash with '#' delimiter

### DIFF
--- a/src/test/java/org/openrewrite/apache/commons/lang/DefaultIfBlankToJdkTest.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/DefaultIfBlankToJdkTest.java
@@ -62,7 +62,7 @@ class DefaultIfBlankToJdkTest implements RewriteTest {
           ));
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # StringUtils.defaultIfBlank(first, "fallback") # first == null || first.isBlank() ? "fallback" : first
       org.apache.commons.lang3.StringUtils # StringUtils.defaultIfBlank(field, "fallback") # field == null || field.isBlank() ? "fallback" : field
       """)
@@ -90,7 +90,7 @@ class DefaultIfBlankToJdkTest implements RewriteTest {
               """.formatted(afterLine)));
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # StringUtils.defaultIfBlank(foo(), "fallback")
       org.apache.commons.lang3.StringUtils # StringUtils.defaultIfBlank(first + second, "fallback")
       """)

--- a/src/test/java/org/openrewrite/apache/commons/lang/IsBlankToJdkTest.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/IsBlankToJdkTest.java
@@ -62,7 +62,7 @@ class IsBlankToJdkTest implements RewriteTest {
           ));
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # StringUtils.isBlank(first) # first == null || first.isBlank()
       org.apache.commons.lang3.StringUtils # StringUtils.isBlank(field) # field == null || field.isBlank()
       org.apache.commons.lang3.StringUtils # StringUtils.isBlank(this.field) # this.field == null || this.field.isBlank()
@@ -97,7 +97,7 @@ class IsBlankToJdkTest implements RewriteTest {
               """.formatted(afterLine)));
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # !StringUtils.isBlank(first) # first != null && !first.isBlank()
       org.apache.commons.lang3.StringUtils # !StringUtils.isNotBlank(first) # first == null || first.isBlank()
       org.apache.commons.lang3.StringUtils # !(StringUtils.isBlank(first)) # first != null && !first.isBlank()
@@ -203,7 +203,7 @@ class IsBlankToJdkTest implements RewriteTest {
           ));
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # StringUtils.isBlank(foo())
       org.apache.commons.lang3.StringUtils # StringUtils.isBlank(first + second)
       org.apache.commons.lang3.StringUtils # StringUtils.isNotBlank(foo())

--- a/src/test/java/org/openrewrite/apache/commons/lang/IsNotEmptyToJdkTest.java
+++ b/src/test/java/org/openrewrite/apache/commons/lang/IsNotEmptyToJdkTest.java
@@ -106,7 +106,7 @@ class IsNotEmptyToJdkTest implements RewriteTest {
         );
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # StringUtils.isEmpty(first) # first == null || first.isEmpty()
       org.apache.commons.lang3.StringUtils # StringUtils.isEmpty(field) # field == null || field.isEmpty()
       org.apache.commons.lang3.StringUtils # StringUtils.isEmpty(this.field) # this.field == null || this.field.isEmpty()
@@ -141,7 +141,7 @@ class IsNotEmptyToJdkTest implements RewriteTest {
               """.formatted(afterLine)));
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # !StringUtils.isEmpty(first) # !(first == null || first.isEmpty())
       org.apache.commons.lang3.StringUtils # !StringUtils.isNotEmpty(first) # !(first != null && !first.isEmpty())
       org.apache.commons.lang3.StringUtils # !(StringUtils.isEmpty(first)) # !(first == null || first.isEmpty())
@@ -209,7 +209,7 @@ class IsNotEmptyToJdkTest implements RewriteTest {
         );
     }
 
-    @CsvSource(delimiter = '#', textBlock = """
+    @CsvSource(delimiter = '#', commentCharacter = '\0', textBlock = """
       org.apache.commons.lang3.StringUtils # StringUtils.isEmpty(foo())
       org.apache.commons.lang3.StringUtils # StringUtils.isEmpty(first + second)
       org.apache.commons.lang3.StringUtils # StringUtils.isNotEmpty(foo())


### PR DESCRIPTION
## Summary
- JUnit Jupiter Params 5.13+ enforces that `@CsvSource`'s `delimiter`, `quoteCharacter`, and `commentCharacter` must all differ; the default `commentCharacter` (`'#'`) clashed with our `delimiter = '#'`, breaking 8 parameterized tests on `main`.
- Added `commentCharacter = '\0'` to each affected `@CsvSource` in `DefaultIfBlankToJdkTest`, `IsBlankToJdkTest`, and `IsNotEmptyToJdkTest`, effectively disabling comment handling while satisfying the distinctness check.

## Test plan
- [x] `./gradlew test --tests DefaultIfBlankToJdkTest --tests IsBlankToJdkTest --tests IsNotEmptyToJdkTest`