### PR TITLE
Fix AddTimeUnitArgument crash on arithmetic argument expressions

### DIFF
--- a/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
@@ -22,12 +22,14 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.Space;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -68,20 +70,32 @@ public class AddTimeUnitArgument extends Recipe {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
                 if (matcher.matches(m)) {
                     JavaTemplate template = JavaTemplate
-                            .builder(StringUtils.repeat("#{any()}, ", m.getArguments().size()) + "TimeUnit.#{}")
+                            .builder("TimeUnit.#{}")
                             .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "httpclient5", "httpcore5"))
                             .imports("java.util.concurrent.TimeUnit")
                             .build();
 
-                    List<Object> arguments = new ArrayList<>(m.getArguments());
-                    arguments.add(timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS);
-
-                    m = template.apply(
+                    J.MethodInvocation templated = template.apply(
                             updateCursor(m),
                             m.getCoordinates().replaceArguments(),
-                            arguments.toArray(new Object[0])
+                            timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS
                     );
+                    Expression timeUnitArgument = templated.getArguments().get(0).withPrefix(Space.SINGLE_SPACE);
+
+                    List<Expression> arguments = new ArrayList<>(m.getArguments());
+                    arguments.add(timeUnitArgument);
+                    m = m.withArguments(arguments);
+
+                    JavaType.Method methodType = m.getMethodType();
+                    if (methodType != null) {
+                        List<JavaType> parameterTypes = new ArrayList<>(methodType.getParameterTypes());
+                        parameterTypes.add(timeUnitArgument.getType());
+                        List<String> parameterNames = new ArrayList<>(methodType.getParameterNames());
+                        parameterNames.add("timeUnit");
+                        methodType = methodType.withParameterTypes(parameterTypes).withParameterNames(parameterNames);
+                        m = m.withMethodType(methodType).withName(m.getName().withType(methodType));
+                    }
                     maybeAddImport("java.util.concurrent.TimeUnit");
                 }
                 return m;

--- a/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
@@ -24,7 +24,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.Expression;
@@ -70,7 +69,6 @@ public class AddTimeUnitArgument extends Recipe {
                 if (matcher.matches(m)) {
                     J.MethodInvocation templated = JavaTemplate
                             .builder("TimeUnit.#{}")
-                            .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "httpclient5", "httpcore5"))
                             .imports("java.util.concurrent.TimeUnit")
                             .build()
                             .apply(

--- a/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
@@ -22,6 +22,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.JavaTemplate;
@@ -31,8 +32,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @EqualsAndHashCode(callSuper = false)
@@ -82,18 +81,13 @@ public class AddTimeUnitArgument extends Recipe {
                             timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS
                     );
                     Expression timeUnitArgument = templated.getArguments().get(0).withPrefix(Space.SINGLE_SPACE);
-
-                    List<Expression> arguments = new ArrayList<>(m.getArguments());
-                    arguments.add(timeUnitArgument);
-                    m = m.withArguments(arguments);
+                    m = m.withArguments(ListUtils.concat(m.getArguments(), timeUnitArgument));
 
                     JavaType.Method methodType = m.getMethodType();
                     if (methodType != null) {
-                        List<JavaType> parameterTypes = new ArrayList<>(methodType.getParameterTypes());
-                        parameterTypes.add(timeUnitArgument.getType());
-                        List<String> parameterNames = new ArrayList<>(methodType.getParameterNames());
-                        parameterNames.add("timeUnit");
-                        methodType = methodType.withParameterTypes(parameterTypes).withParameterNames(parameterNames);
+                        methodType = methodType
+                                .withParameterTypes(ListUtils.concat(methodType.getParameterTypes(), timeUnitArgument.getType()))
+                                .withParameterNames(ListUtils.concat(methodType.getParameterNames(), "timeUnit"));
                         m = m.withMethodType(methodType).withName(m.getName().withType(methodType));
                     }
                     maybeAddImport("java.util.concurrent.TimeUnit");

--- a/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
+++ b/src/main/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgument.java
@@ -68,18 +68,16 @@ public class AddTimeUnitArgument extends Recipe {
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
                 if (matcher.matches(m)) {
-                    JavaTemplate template = JavaTemplate
+                    J.MethodInvocation templated = JavaTemplate
                             .builder("TimeUnit.#{}")
-                            .contextSensitive()
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, "httpclient5", "httpcore5"))
                             .imports("java.util.concurrent.TimeUnit")
-                            .build();
-
-                    J.MethodInvocation templated = template.apply(
-                            updateCursor(m),
-                            m.getCoordinates().replaceArguments(),
-                            timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS
-                    );
+                            .build()
+                            .apply(
+                                    updateCursor(m),
+                                    m.getCoordinates().replaceArguments(),
+                                    timeUnit != null ? timeUnit : TimeUnit.MILLISECONDS
+                            );
                     Expression timeUnitArgument = templated.getArguments().get(0).withPrefix(Space.SINGLE_SPACE);
                     m = m.withArguments(ListUtils.concat(m.getArguments(), timeUnitArgument));
 

--- a/src/test/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgumentTest.java
+++ b/src/test/java/org/openrewrite/apache/httpclient5/AddTimeUnitArgumentTest.java
@@ -123,6 +123,35 @@ class AddTimeUnitArgumentTest implements RewriteTest {
     }
 
     @Test
+    void arithmeticTimeoutArgument() {
+        rewriteRun(
+          spec -> spec.recipe(new AddTimeUnitArgument("A method(int)", null)),
+          stubCode,
+          //language=java
+          java(
+                """
+            class B {
+                void test() {
+                    A a = new A();
+                    a.method(60 * 1000);
+                }
+            }
+            """,
+          """
+            import java.util.concurrent.TimeUnit;
+
+            class B {
+                void test() {
+                    A a = new A();
+                    a.method(60 * 1000, TimeUnit.MILLISECONDS);
+                }
+            }
+            """
+          )
+        );
+    }
+
+    @Test
     void doesModifyMethodsWithMoreThanOneArgument() {
         rewriteRun(
           spec -> spec.recipe(new AddTimeUnitArgument("A method(int, float)", null)),


### PR DESCRIPTION
## Problem

`AddTimeUnitArgument` (invoked by `UpgradeApacheHttpClient_5_TimeUnit`) throws `IllegalArgumentException: Could not parse as Java` when the timeout argument is a binary/arithmetic expression such as `60 * 1000`:

```java
RequestConfig.custom()
    .setConnectionRequestTimeout(60 * 1000) // arithmetic expression
    .build();
```

Plain integer literals and variables were handled fine — only binary expressions crashed.

## Root cause

The recipe rebuilt the whole argument list through a `contextSensitive()` `JavaTemplate` of the form `#{any()}, TimeUnit.#{}` with `replaceArguments()`. Re-parsing the original argument inside the synthetic template stub placed the `__TEMPLATE_STOP__` boundary incorrectly for binary expressions, producing unparseable Java.

## Fix

Append the `TimeUnit` argument to the existing argument LST instead of re-templating all arguments via `#{any()}`. The original expression is never re-parsed. The invocation's method type is extended with the new `TimeUnit` parameter so the recipe stays idempotent (the matcher no longer matches after the argument is added).

## Tests

Added `arithmeticTimeoutArgument` reproducing the reported crash; all existing `AddTimeUnitArgumentTest` and httpclient5 tests still pass.

- Fixes #138