### PR TITLE
Make subpackage recursion explicit where these renames depend on it

### DIFF
--- a/src/main/resources/META-INF/rewrite/apache-commons-math-2-3.yml
+++ b/src/main/resources/META-INF/rewrite/apache-commons-math-2-3.yml
@@ -44,3 +44,4 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.commons.math
       newPackageName: org.apache.commons.math3
+      recursive: true

--- a/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
+++ b/src/main/resources/META-INF/rewrite/apache-httpclient-5.yml
@@ -413,6 +413,7 @@ recipeList:
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.hc.core5.http.io.entity.mime
       newPackageName: org.apache.hc.client5.http.entity.mime
+      recursive: true
   - org.openrewrite.java.ChangePackage:
       oldPackageName: org.apache.hc.client5.http.entity.mime.content
       newPackageName: org.apache.hc.client5.http.entity.mime


### PR DESCRIPTION
Two `ChangePackage` rules omit `recursive` while depending on it to move types out of subpackages of `oldPackageName`.

**`apache-commons-math-2-3.yml`** — `org.apache.commons.math` → `org.apache.commons.math3` has to carry `org.apache.commons.math.stat.StatUtils` along with it.

**`apache-httpclient-5.yml`** — this one is step 2 of a deliberate three-step chain:

```yaml
org.apache.http.entity                          -> org.apache.hc.core5.http.io.entity      # recursive: true
org.apache.hc.core5.http.io.entity.mime         -> org.apache.hc.client5.http.entity.mime  # <-- omitted
org.apache.hc.client5.http.entity.mime.content  -> org.apache.hc.client5.http.entity.mime
```

Step 1 relocates `org.apache.http.entity.mime.content.StringBody` under `core5`, step 2 has to move the whole `mime` subtree over to `client5`, and step 3 flattens `.content`. Step 2 only reaches `.content.StringBody` by recursing, so without it the chain stalls at `org.apache.hc.core5.http.io.entity.mime.content.StringBody` — a package that doesn't exist in httpclient5.

## Why now

`ChangePackage.recursive` is `@Nullable` with `required = false` and no documented default, and a null was read **two different ways inside the same recipe**: non-recursive by its preconditions, recursive by its visitor. The upshot was that a subpackage type got renamed only if the file *also* referenced a type sitting directly in `oldPackageName` — so these two rules worked in the test fixtures (which happen to mix both) and silently did nothing for a file that only touched a subpackage.

- openrewrite/rewrite#8382 settles null as non-recursive, which turns that latent dependency into a visible one. I found these two while validating that change downstream.

## Verification

Full `./gradlew test` on this branch, four ways:

| | without rewrite#8382 | with rewrite#8382 |
| --- | --- | --- |
| `origin/main` | 0 failures | **2 failures** |
| this branch | 0 failures | 0 failures |

- So this is correct on its own merits and safe to merge now, independently of rewrite#8382 — it makes explicit what these rules already relied on.
